### PR TITLE
Unify gates into single struct

### DIFF
--- a/packages/backend/src/engine/func/gates.rs
+++ b/packages/backend/src/engine/func/gates.rs
@@ -7,71 +7,89 @@ pub const MIN_GATE_INPUTS: u8 = 2;
 /// Maximum number of inputs for multi-input logic gates.
 pub const MAX_GATE_INPUTS: u8 = 64;
 
-macro_rules! gates {
-    ($($(#[$m:meta])? $Id:ident: $f:expr, $invert:literal),*$(,)?) => {
-        $(
-            $(#[$m])?
-            #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
-            pub struct $Id {
-                bitsize: u8,
-                n_inputs: u8
-            }
-            impl $Id {
-                /// Creates a new instance of the gate with specified bitsize and number of inputs.
-                pub fn new(bitsize: u8, n_inputs: u8) -> Self {
-                    Self {
-                        bitsize: bitsize.clamp(BitArray::MIN_BITSIZE, BitArray::MAX_BITSIZE),
-                        n_inputs: n_inputs.clamp(MIN_GATE_INPUTS, MAX_GATE_INPUTS)
-                    }
-                }
-                /// Returns the number of inputs for this gate.
-                pub fn n_inputs(&self) -> u8 {
-                    self.n_inputs
-                }
-                /// Returns the bitsize for this gate.
-                pub fn bitsize(&self) -> u8 {
-                    self.bitsize
-                }
-            }
-            impl Component for $Id {
-                fn ports(&self, _: &CircuitGraphMap) -> Vec<PortProperties> {
-                    port_list(&[
-                        // inputs
-                        (PortProperties { ty: PortType::Input, bitsize: self.bitsize }, usize::from(self.n_inputs)),
-                        // outputs
-                        (PortProperties { ty: PortType::Output, bitsize: self.bitsize }, 1),
-                    ])
-                }
-                fn run_inner(&self, ctx: RunContext<'_>) -> Vec<PortUpdate> {
-                    let value = ctx.new_ports[..usize::from(self.n_inputs)].iter()
-                        .cloned()
-                        .reduce($f)
-                        .unwrap_or_else(|| bitarr![X; self.bitsize]);
-    
-                    vec![PortUpdate {
-                        index: usize::from(self.n_inputs),
-                        value: if $invert { !value } else { value }
-                    }]
-                }
-            }
-            
-        )*
+/// The gate type for [`Gate`].
+/// 
+/// This defines the logic and appearance of the gate.
+#[expect(missing_docs)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+pub enum GateKind {
+    And, Or, Xor, Nand, Nor, Xnor
+}
+impl GateKind {
+    fn reduce(self, it: impl IntoIterator<Item=BitArray>) -> Option<BitArray> {
+        let it = it.into_iter();
+        match self {
+            GateKind::And  => it.reduce(|a, b| a & b),
+            GateKind::Or   => it.reduce(|a, b| a | b),
+            GateKind::Xor  => it.reduce(|a, b| a ^ b),
+            GateKind::Nand => it.reduce(|a, b| a & b).map(|r| !r),
+            GateKind::Nor  => it.reduce(|a, b| a | b).map(|r| !r),
+            GateKind::Xnor => it.reduce(|a, b| a ^ b).map(|r| !r),
+        }
+    }
+
+    /// The name of the gate
+    pub fn name(self) -> &'static str {
+        match self {
+            GateKind::And  => "And",
+            GateKind::Or   => "Or",
+            GateKind::Xor  => "Xor",
+            GateKind::Nand => "Nand",
+            GateKind::Nor  => "Nor",
+            GateKind::Xnor => "Xnor",
+        }
     }
 }
+/// A multi-input logic gate.
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+pub struct Gate {
+    kind: GateKind,
+    bitsize: u8,
+    n_inputs: u8
+}
+impl Gate {
+    /// Creates a new instance of the gate with specified bitsize and number of inputs.
+    pub fn new(kind: GateKind, bitsize: u8, n_inputs: u8) -> Self {
+        Self {
+            kind,
+            bitsize: bitsize.clamp(BitArray::MIN_BITSIZE, BitArray::MAX_BITSIZE),
+            n_inputs: n_inputs.clamp(MIN_GATE_INPUTS, MAX_GATE_INPUTS)
+        }
+    }
 
-gates! {
-    /// An AND gate component.
-    And:  |a, b| a & b, false,
-    /// An OR gate component.
-    Or:   |a, b| a | b, false,
-    /// An XOR gate component.
-    Xor:  |a, b| a ^ b, false,
-    /// A NAND gate component.
-    Nand: |a, b| a & b, true,
-    /// A NOR gate component.
-    Nor:  |a, b| a | b, true,
-    /// A XNOR gate component.
-    Xnor: |a, b| a ^ b, true,
+    /// The gate type.
+    pub fn kind(&self) -> GateKind {
+        self.kind
+    }
+    /// Returns the number of inputs for this gate.
+    pub fn n_inputs(&self) -> u8 {
+        self.n_inputs
+    }
+    /// Returns the bitsize for this gate.
+    pub fn bitsize(&self) -> u8 {
+        self.bitsize
+    }
+}
+impl Component for Gate {
+    fn ports(&self, _: &CircuitGraphMap) -> Vec<PortProperties> {
+        port_list(&[
+            // inputs
+            (PortProperties { ty: PortType::Input, bitsize: self.bitsize }, usize::from(self.n_inputs)),
+            // outputs
+            (PortProperties { ty: PortType::Output, bitsize: self.bitsize }, 1),
+        ])
+    }
+
+    fn run_inner(&self, ctx: RunContext<'_>) -> Vec<PortUpdate> {
+        let inputs = ctx.new_ports[..usize::from(self.n_inputs)].iter().cloned();
+        let output = self.kind.reduce(inputs)
+            .unwrap_or_else(|| bitarr![X; self.bitsize]);
+        
+        vec![PortUpdate {
+            index: usize::from(self.n_inputs),
+            value: output
+        }]
+    }
 }
 
 /// A NOT gate component.
@@ -144,7 +162,7 @@ mod tests {
     use super::*;
     #[test]
     fn test_and_gate() {
-        let gate = And::new(1, 2);
+        let gate = Gate::new(GateKind::And, 1, 2);
         let in_a = bitarr![0];
         let in_b = bitarr![1];
 
@@ -167,7 +185,7 @@ mod tests {
 
     #[test]
     fn test_and_gate_multi_bit() {
-        let gate = And::new(4, 2);
+        let gate = Gate::new(GateKind::And, 4, 2);
         let in_a = bitarr![1, 0, 1, 1];
         let in_b = bitarr![1, 1, 0, 0];
 
@@ -188,7 +206,7 @@ mod tests {
 
     #[test]
     fn test_and_gate_3input_4bit() {
-        let gate = And::new(4, 3); // 3 inputs, 4-bit each
+        let gate = Gate::new(GateKind::And, 4, 3); // 3 inputs, 4-bit each
         let in_a = bitarr![1, 0, 1, 1];
         let in_b = bitarr![1, 1, 0, 0];
         let in_c = bitarr![1, 1, 1, 0];
@@ -210,7 +228,7 @@ mod tests {
 
     #[test]
     fn test_or_gate() {
-        let gate = Or::new(1, 2);
+        let gate = Gate::new(GateKind::Or, 1, 2);
         let in_a = bitarr![0];
         let in_b = bitarr![1];
 
@@ -231,7 +249,7 @@ mod tests {
 
     #[test]
     fn test_or_gate_multi_bit() {
-        let gate = Or::new(4, 2);
+        let gate = Gate::new(GateKind::Or, 4, 2);
         let in_a = bitarr![1, 0, 1, 1];
         let in_b = bitarr![1, 1, 0, 0];
 
@@ -252,7 +270,7 @@ mod tests {
 
     #[test]
     fn test_or_gate_3input_4bit() {
-        let gate = Or::new(4, 3);
+        let gate = Gate::new(GateKind::Or, 4, 3);
         let in_a = bitarr![1, 0, 1, 1];
         let in_b = bitarr![1, 1, 0, 0];
         let in_c = bitarr![0, 1, 1, 0];
@@ -274,7 +292,7 @@ mod tests {
 
     #[test]
     fn test_xor_gate() {
-        let gate = Xor::new(1, 2);
+        let gate = Gate::new(GateKind::Xor, 1, 2);
         let in_a = bitarr![0];
         let in_b = bitarr![1];
 
@@ -295,7 +313,7 @@ mod tests {
 
     #[test]
     fn test_xor_gate_multi_bit() {
-        let gate = Xor::new(4, 2);
+        let gate = Gate::new(GateKind::Xor, 4, 2);
         let in_a = bitarr![1, 0, 1, 1];
         let in_b = bitarr![1, 1, 0, 1];
 
@@ -316,7 +334,7 @@ mod tests {
 
     #[test]
     fn test_xor_gate_3input_4bit() {
-        let gate = Xor::new(4, 3);
+        let gate = Gate::new(GateKind::Xor, 4, 3);
         let in_a = bitarr![1, 0, 1, 1];
         let in_b = bitarr![1, 1, 0, 1];
         let in_c = bitarr![0, 1, 1, 0];
@@ -338,7 +356,7 @@ mod tests {
 
     #[test]
     fn test_nand_gate() {
-        let gate = Nand::new(1, 2);
+        let gate = Gate::new(GateKind::Nand, 1, 2);
         let in_a = bitarr![0];
         let in_b = bitarr![1];
 
@@ -358,7 +376,7 @@ mod tests {
 
     #[test]
     fn test_nand_gate_multi_bit() {
-        let gate = Nand::new(4, 2);
+        let gate = Gate::new(GateKind::Nand, 4, 2);
         let in_a = bitarr![1, 0, 1, 1];
         let in_b = bitarr![1, 1, 0, 1];
 
@@ -378,7 +396,7 @@ mod tests {
 
     #[test]
     fn test_nand_gate_3input_4bit() {
-        let gate = Nand::new(4, 3);
+        let gate = Gate::new(GateKind::Nand, 4, 3);
         let in_a = bitarr![1, 0, 1, 1];
         let in_b = bitarr![1, 1, 0, 1];
         let in_c = bitarr![1, 1, 1, 0];
@@ -400,7 +418,7 @@ mod tests {
 
     #[test]
     fn test_nor_gate() {
-        let gate = Nor::new(1, 2);
+        let gate = Gate::new(GateKind::Nor, 1, 2);
         let in_a = bitarr![0];
         let in_b = bitarr![1];
 
@@ -420,7 +438,7 @@ mod tests {
 
     #[test]
     fn test_nor_gate_multi_bit() {
-        let gate = Nor::new(4, 2);
+        let gate = Gate::new(GateKind::Nor, 4, 2);
         let in_a = bitarr![1, 0, 1, 1];
         let in_b = bitarr![1, 1, 0, 1];
 
@@ -440,7 +458,7 @@ mod tests {
 
     #[test]
     fn test_nor_gate_3input_4bit() {
-        let gate = Nor::new(4, 3);
+        let gate = Gate::new(GateKind::Nor, 4, 3);
         let in_a = bitarr![1, 0, 1, 1];
         let in_b = bitarr![1, 1, 0, 1];
         let in_c = bitarr![0, 1, 1, 0];
@@ -462,7 +480,7 @@ mod tests {
 
     #[test]
     fn test_xnor_gate() {
-        let gate = Xnor::new(1, 2);
+        let gate = Gate::new(GateKind::Xnor, 1, 2);
         let in_a = bitarr![0];
         let in_b = bitarr![1];
 
@@ -482,7 +500,7 @@ mod tests {
 
     #[test]
     fn test_xnor_gate_multi_bit() {
-        let gate = Xnor::new(4, 2);
+        let gate = Gate::new(GateKind::Xnor, 4, 2);
         let in_a = bitarr![1, 0, 1, 1];
         let in_b = bitarr![1, 1, 0, 1];
 
@@ -502,7 +520,7 @@ mod tests {
 
     #[test]
     fn test_xnor_gate_3input_4bit() {
-        let gate = Xnor::new(4, 3);
+        let gate = Gate::new(GateKind::Xnor, 4, 3);
         let in_a = bitarr![1, 0, 1, 1];
         let in_b = bitarr![1, 1, 0, 1];
         let in_c = bitarr![0, 1, 1, 0];
@@ -638,7 +656,7 @@ mod tests {
         #[test]
         #[should_panic]
         fn input_validate_and() {
-            let gate = And::new(4, 2);
+            let gate = Gate::new(GateKind::And, 4, 2);
             // Should fail input validation
             let bad_in = bitarr![1, 1, 1];
             let good_in = bitarr![1, 0, 1, 0];
@@ -653,7 +671,7 @@ mod tests {
         #[test]
         #[should_panic]
         fn input_validate_or() {
-            let gate = Or::new(4, 2);
+            let gate = Gate::new(GateKind::Or, 4, 2);
             // Should fail input validation
             let bad_in = bitarr![1, 1, 1];
             let good_in = bitarr![1, 0, 1, 0];
@@ -668,7 +686,7 @@ mod tests {
         #[test]
         #[should_panic]
         fn input_validate_xor() {
-            let gate = Xor::new(4, 2);
+            let gate = Gate::new(GateKind::Xor, 4, 2);
             // Should fail input validation
             let bad_in = bitarr![1, 1, 1];
             let good_in = bitarr![1, 0, 1, 0];
@@ -683,7 +701,7 @@ mod tests {
         #[test]
         #[should_panic]
         fn input_validate_nand() {
-            let gate = Nand::new(4, 2);
+            let gate = Gate::new(GateKind::Nand, 4, 2);
             // Should fail input validation
             let bad_in = bitarr![1, 1, 1];
             let good_in = bitarr![1, 0, 1, 0];
@@ -698,7 +716,7 @@ mod tests {
         #[test]
         #[should_panic]
         fn input_validate_nor() {
-            let gate = Nor::new(4, 2);
+            let gate = Gate::new(GateKind::Nor, 4, 2);
             // Should fail input validation
             let bad_in = bitarr![1, 1, 1];
             let good_in = bitarr![1, 0, 1, 0];
@@ -713,7 +731,7 @@ mod tests {
         #[test]
         #[should_panic]
         fn input_validate_xnor() {
-            let gate = Xnor::new(4, 2);
+            let gate = Gate::new(GateKind::Xnor, 4, 2);
             // Should fail input validation
             let bad_in = bitarr![1, 1, 1];
             let good_in = bitarr![1, 0, 1, 0];

--- a/packages/backend/src/engine/func/gates.rs
+++ b/packages/backend/src/engine/func/gates.rs
@@ -16,7 +16,10 @@ pub enum GateKind {
     And, Or, Xor, Nand, Nor, Xnor
 }
 impl GateKind {
-    fn reduce(self, it: impl IntoIterator<Item=BitArray>) -> Option<BitArray> {
+    /// Takes a sequence of inputs and reduces them to a single value using the kind's operation.
+    /// 
+    /// This returns `None` if the iterator is empty.
+    pub fn reduce(self, it: impl IntoIterator<Item=BitArray>) -> Option<BitArray> {
         let it = it.into_iter();
         match self {
             GateKind::And  => it.reduce(|a, b| a & b),
@@ -28,7 +31,7 @@ impl GateKind {
         }
     }
 
-    /// The name of the gate
+    /// The name of the gate.
     pub fn name(self) -> &'static str {
         match self {
             GateKind::And  => "And",

--- a/packages/backend/src/engine/func/mod.rs
+++ b/packages/backend/src/engine/func/mod.rs
@@ -129,7 +129,7 @@ pub trait Component {
 #[allow(missing_docs)]
 pub enum ComponentFn {
     // Gates
-    And, Or, Xor, Nand, Nor, Xnor, Not, TriState,
+    Gate, Not, TriState,
     // Wiring
     Input, Output, Constant, Splitter,
     // Muxes

--- a/packages/backend/src/engine/graph.rs
+++ b/packages/backend/src/engine/graph.rs
@@ -238,7 +238,7 @@ impl IndexMut<FunctionKey> for CircuitGraph {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::engine::func::{And, Not, ComponentFn};
+    use crate::engine::func::{ComponentFn, Gate, GateKind, Not};
 
     #[test]
     fn test_join() {
@@ -250,8 +250,8 @@ mod tests {
         let value2 = graph.add_value();
 
         // Create function nodes (and gate, not gate)
-        let and =  ComponentFn::And(And::new(8, 2));
-        let not= ComponentFn::Not(Not::new(8));
+        let and = ComponentFn::Gate(Gate::new(GateKind::And, 8, 2));
+        let not = ComponentFn::Not(Not::new(8));
 
         let func1 = graph.add_function(FunctionNode::new(and, &graphs));
         let func2 = graph.add_function(FunctionNode::new(not, &graphs));
@@ -285,7 +285,7 @@ mod tests {
         let value1 = graph.add_value();
 
         // Create function nodes (and gate, not gate)
-        let and = ComponentFn::And(And::new(8, 2));
+        let and = ComponentFn::Gate(Gate::new(GateKind::And, 8, 2));
         let not = ComponentFn::Not(Not::new(8));
 
         let func1 = graph.add_function(FunctionNode::new(and, &graphs));

--- a/packages/backend/src/engine/mod.rs
+++ b/packages/backend/src/engine/mod.rs
@@ -37,7 +37,7 @@ mod tests {
         let (_, b_in) = circuit.add_input(BitArray::from(b));
         let (out_g, out) = circuit.add_output(64);
         // Gates
-        let gate = circuit.add_function_node(func::Xor::new(64, 2));
+        let gate = circuit.add_function_node(func::Gate::new(func::GateKind::Xor, 64, 2));
 
         circuit.connect_all(gate, &[a_in, b_in, out]);
         circuit.run(&[a_in, b_in]);
@@ -67,9 +67,9 @@ mod tests {
         let (out_g, out) = circuit.add_output(64);
         // Gates
         let gates = [
-            circuit.add_function_node(func::Xor::new(64, 2)),
-            circuit.add_function_node(func::Xor::new(64, 2)),
-            circuit.add_function_node(func::Xor::new(64, 2)),
+            circuit.add_function_node(func::Gate::new(func::GateKind::Xor, 64, 2)),
+            circuit.add_function_node(func::Gate::new(func::GateKind::Xor, 64, 2)),
+            circuit.add_function_node(func::Gate::new(func::GateKind::Xor, 64, 2)),
         ];
 
         circuit.connect_all(gates[0], &[a_in, b_in, ab_mid]);
@@ -149,8 +149,8 @@ mod tests {
         let (out0_g, out0) = circuit.add_output(1);
         let (out1_g, out1) = circuit.add_output(1);
         let gates = [
-            circuit.add_function_node(func::Nand::new(1, 2)),
-            circuit.add_function_node(func::Nand::new(1, 2)),
+            circuit.add_function_node(func::Gate::new(func::GateKind::Nand, 1, 2)),
+            circuit.add_function_node(func::Gate::new(func::GateKind::Nand, 1, 2)),
         ];
 
         circuit.connect_all(gates[0], &[inp, out1, out0]);
@@ -245,8 +245,8 @@ mod tests {
             circuit.add_output(1), // Q'
         ];
         let [rnand, snand] = [
-            circuit.add_function_node(func::Nand::new(1, 2)),
-            circuit.add_function_node(func::Nand::new(1, 2)),
+            circuit.add_function_node(func::Gate::new(func::GateKind::Nand, 1, 2)),
+            circuit.add_function_node(func::Gate::new(func::GateKind::Nand, 1, 2)),
         ];
 
         // R = 1, S = 1
@@ -297,10 +297,10 @@ mod tests {
         // nodes
         let [dnot, dnand, dpnand, rnand, snand] = [
             circuit.add_function_node(func::Not::new(1)),
-            circuit.add_function_node(func::Nand::new(1, 2)),
-            circuit.add_function_node(func::Nand::new(1, 2)),
-            circuit.add_function_node(func::Nand::new(1, 2)),
-            circuit.add_function_node(func::Nand::new(1, 2)),
+            circuit.add_function_node(func::Gate::new(func::GateKind::Nand, 1, 2)),
+            circuit.add_function_node(func::Gate::new(func::GateKind::Nand, 1, 2)),
+            circuit.add_function_node(func::Gate::new(func::GateKind::Nand, 1, 2)),
+            circuit.add_function_node(func::Gate::new(func::GateKind::Nand, 1, 2)),
         ];
 
         circuit.connect_all(dnot, &[din, dinp]);
@@ -342,7 +342,7 @@ mod tests {
             sub_circuit.add_input(bitarr![0]),
             sub_circuit.add_output(1),
         ];
-        let gate = sub_circuit.add_function_node(func::Nand::new(1, 2));
+        let gate = sub_circuit.add_function_node(func::Gate::new(func::GateKind::Nand, 1, 2));
         sub_circuit.connect_all(gate, &[a, b, out]);
 
         // Using gates
@@ -395,8 +395,8 @@ mod tests {
                 rs_circuit.add_output(1), // Q'
             ];
             let [rnand, snand] = [
-                rs_circuit.add_function_node(func::Nand::new(1, 2)),
-                rs_circuit.add_function_node(func::Nand::new(1, 2)),
+                rs_circuit.add_function_node(func::Gate::new(func::GateKind::Nand, 1, 2)),
+                rs_circuit.add_function_node(func::Gate::new(func::GateKind::Nand, 1, 2)),
             ];
             rs_circuit.connect_all(rnand, &[r, q, qp]);
             rs_circuit.connect_all(snand, &[s, qp, q]);
@@ -417,8 +417,8 @@ mod tests {
         // nodes
         let [dnot, dnand, dpnand, rs] = [
             d_circuit.add_function_node(func::Not::new(1)),
-            d_circuit.add_function_node(func::Nand::new(1, 2)),
-            d_circuit.add_function_node(func::Nand::new(1, 2)),
+            d_circuit.add_function_node(func::Gate::new(func::GateKind::Nand, 1, 2)),
+            d_circuit.add_function_node(func::Gate::new(func::GateKind::Nand, 1, 2)),
             d_circuit.add_function_node(func::Subcircuit::new(rs_key))
         ];
 
@@ -461,10 +461,10 @@ mod tests {
         let (out_g, out) = circuit.add_output(1);
         // Gates
         let gates = [
-            circuit.add_function_node(func::Xor::new(1, 2)),
-            circuit.add_function_node(func::Xor::new(1, 2)),
-            circuit.add_function_node(func::Xor::new(1, 2)),
-            circuit.add_function_node(func::Xor::new(1, 2)),
+            circuit.add_function_node(func::Gate::new(func::GateKind::Xor, 1, 2)),
+            circuit.add_function_node(func::Gate::new(func::GateKind::Xor, 1, 2)),
+            circuit.add_function_node(func::Gate::new(func::GateKind::Xor, 1, 2)),
+            circuit.add_function_node(func::Gate::new(func::GateKind::Xor, 1, 2)),
         ];
 
         circuit.connect_all(gates[0], &[a_in, b_in, ab_mid]);

--- a/packages/backend/src/engine/repr.rs
+++ b/packages/backend/src/engine/repr.rs
@@ -265,7 +265,7 @@ impl Circuit<'_> {
 mod tests {
     use super::*;
     use crate::bitarr;
-    use func::{And, Not, ComponentFn};
+    use func::{Gate, GateKind, Not, ComponentFn};
 
     #[test]
     fn test_replace() {
@@ -290,7 +290,7 @@ mod tests {
         let value1 = circuit.add_value_node();
         let value2 = circuit.add_value_node();
 
-        let and =  ComponentFn::And(And::new(8, 2));
+        let and =  ComponentFn::Gate(Gate::new(GateKind::And, 8, 2));
         let not= ComponentFn::Not(Not::new(8));
 
         let func1 = circuit.add_function_node(and);
@@ -317,7 +317,7 @@ mod tests {
 
         let value1 = circuit.add_value_node();
 
-        let and =  ComponentFn::And(And::new(8, 2));
+        let and =  ComponentFn::Gate(Gate::new(GateKind::And, 8, 2));
         let not= ComponentFn::Not(Not::new(8));
 
         let func1 = circuit.add_function_node(and);

--- a/packages/backend/src/middle_end/func/gates.rs
+++ b/packages/backend/src/middle_end/func/gates.rs
@@ -1,48 +1,36 @@
 use crate::engine::func;
 use crate::middle_end::func::{AbsoluteComponentBounds, PhysicalComponent, PhysicalInitContext, RelativeComponentBounds};
 
-/// A macro to define gate components for AND, OR, XOR, NAND, NOR, and XNOR gates which all have same structure.
-macro_rules! gates {
-    ($($(#[$m:meta])? $Id:ident),*$(,)?) => {
-        $(
-            $(#[$m])?
-            #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
-            /// A gate component with a variable number of inputs.
-           pub struct $Id {
-                sim: func::$Id
-            }
-            impl PhysicalComponent for $Id {
-                fn engine_component(&self) -> Option<func::ComponentFn> {
-                    Some(self.sim.into())
-                }
+pub use func::GateKind;
 
-                fn component_name(&self) -> &'static str {
-                    stringify!($Id)
-                }
-
-                fn bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
-                    // The origin is at the output port, which is at (4,2) in absolute coordinates.
-                    let bounds = [(-4, -2), (0, 2)];
-                    let inputs = self.sim.n_inputs() as i32;
-                    
-                    let mut ports = vec![];
-                    // Input ports
-                    // For a 4-input gate, you have (-4, -3), (-4, -1), (-4, 1), (-4, 3)
-                    // For a 5-input gate, you have (-4, -4), (-4, -2), (-4, 0), (-4, 2), (-4, 4)
-                    ports.extend((0..inputs).map(|i| (-4, 2 * i - (inputs - 1))));
-                    ports.push((0, 0)); // Output port
-
-                    RelativeComponentBounds { bounds, ports }
-                }
-
-
-            }
-
-        )*
-    }
+/// A gate component with a variable number of inputs.
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+pub struct Gate {
+    sim: func::Gate
 }
-gates! {
-    And,Or,Xor,Nand,Nor,Xnor,
+impl PhysicalComponent for Gate {
+    fn engine_component(&self) -> Option<func::ComponentFn> {
+        Some(self.sim.into())
+    }
+
+    fn component_name(&self) -> &'static str {
+        self.sim.kind().name()
+    }
+
+    fn bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
+        // The origin is at the output port, which is at (4,2) in absolute coordinates.
+        let bounds = [(-4, -2), (0, 2)];
+        let inputs = self.sim.n_inputs() as i32;
+        
+        let mut ports = vec![];
+        // Input ports
+        // For a 4-input gate, you have (-4, -3), (-4, -1), (-4, 1), (-4, 3)
+        // For a 5-input gate, you have (-4, -4), (-4, -2), (-4, 0), (-4, 2), (-4, 4)
+        ports.extend((0..inputs).map(|i| (-4, 2 * i - (inputs - 1))));
+        ports.push((0, 0)); // Output port
+
+        RelativeComponentBounds { bounds, ports }
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]

--- a/packages/backend/src/middle_end/func/mod.rs
+++ b/packages/backend/src/middle_end/func/mod.rs
@@ -228,7 +228,7 @@ pub enum PhysicalComponentEnum {
     // Misc
     Text, Subcircuit,
     //Gates
-    And, Or, Xor, Nand, Nor, Xnor, Not, TriState,
+    Gate, Not, TriState,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This removes the macro used to implement the N-input logic gates, replacing it with a single struct.

Since the structs are already unified on most logic, this is reasonable since it reduces redundancy in documentation and lets us get rid of one macro.
