### PR TITLE
Middle-end serializable properties

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,7 @@ dependencies = [
  "serde_json",
  "slotmap",
  "strum",
+ "thiserror",
 ]
 
 [[package]]
@@ -452,6 +453,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,9 +220,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "libloading"
@@ -305,9 +305,9 @@ checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "petgraph"
@@ -323,9 +323,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "proc-macro2"
@@ -338,9 +338,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -417,9 +417,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -428,15 +428,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "version_check"
@@ -452,6 +452,6 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "zmij"
-version = "1.0.19"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,6 +23,7 @@ dependencies = [
  "serde",
  "serde_json",
  "slotmap",
+ "strum",
 ]
 
 [[package]]
@@ -207,6 +208,12 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "indexmap"
@@ -413,6 +420,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
 dependencies = [
  "version_check",
+]
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/packages/backend/Cargo.toml
+++ b/packages/backend/Cargo.toml
@@ -9,3 +9,4 @@ petgraph = "0.8.3"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 slotmap = "1.0.7"
+strum = { version = "0.28.0", features = ["derive"] }

--- a/packages/backend/Cargo.toml
+++ b/packages/backend/Cargo.toml
@@ -10,3 +10,4 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 slotmap = "1.0.7"
 strum = { version = "0.28.0", features = ["derive"] }
+thiserror = "2.0.18"

--- a/packages/backend/src/engine/func/gates.rs
+++ b/packages/backend/src/engine/func/gates.rs
@@ -11,7 +11,7 @@ pub const MAX_GATE_INPUTS: u8 = 64;
 /// 
 /// This defines the logic and appearance of the gate.
 #[expect(missing_docs)]
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, strum::IntoStaticStr)]
 pub enum GateKind {
     And, Or, Xor, Nand, Nor, Xnor
 }
@@ -28,18 +28,6 @@ impl GateKind {
             GateKind::Nand => it.reduce(|a, b| a & b).map(|r| !r),
             GateKind::Nor  => it.reduce(|a, b| a | b).map(|r| !r),
             GateKind::Xnor => it.reduce(|a, b| a ^ b).map(|r| !r),
-        }
-    }
-
-    /// The name of the gate.
-    pub fn name(self) -> &'static str {
-        match self {
-            GateKind::And  => "And",
-            GateKind::Or   => "Or",
-            GateKind::Xor  => "Xor",
-            GateKind::Nand => "Nand",
-            GateKind::Nor  => "Nor",
-            GateKind::Xnor => "Xnor",
         }
     }
 }

--- a/packages/backend/src/engine/func/muxes.rs
+++ b/packages/backend/src/engine/func/muxes.rs
@@ -23,9 +23,12 @@ impl Mux {
         }
     }
 
+    pub(crate) fn n_inputs_from(selsize: u8) -> usize {
+        1 << selsize
+    }
     /// The number of inputs.
     pub fn n_inputs(self) -> usize {
-        1 << self.selsize
+        Mux::n_inputs_from(self.selsize)
     }
 }
 impl Component for Mux {
@@ -65,9 +68,12 @@ impl Demux {
         }
     }
 
+    pub(crate) fn n_outputs_from(selsize: u8) -> usize {
+        1 << selsize
+    }
     /// The number of outputs.
     pub fn n_outputs(self) -> usize {
-        1 << self.selsize
+        Demux::n_outputs_from(self.selsize)
     }
 }
 impl Component for Demux {
@@ -112,9 +118,12 @@ impl Decoder {
         }
     }
 
+    pub(crate) fn n_outputs_from(selsize: u8) -> usize {
+        1 << selsize
+    }
     /// The number of outputs
     pub fn n_outputs(self) -> usize {
-        1 << self.selsize
+        Self::n_outputs_from(self.selsize)
     }
 }
 impl Component for Decoder {

--- a/packages/backend/src/middle_end/func/gates.rs
+++ b/packages/backend/src/middle_end/func/gates.rs
@@ -1,26 +1,29 @@
 use crate::engine::func;
-use crate::middle_end::func::{AbsoluteComponentBounds, PhysicalComponent, PhysicalInitContext, RelativeComponentBounds};
+use crate::middle_end::func::{AbsoluteComponentBounds, Orientation, PhysicalComponent, PhysicalInitContext, RelativeComponentBounds};
 
 pub use func::GateKind;
 
 /// A gate component with a variable number of inputs.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Gate {
-    sim: func::Gate
+    kind: GateKind,
+    bitsize: u8,
+    n_inputs: u8,
+    orientation: Orientation
 }
 impl PhysicalComponent for Gate {
-    fn engine_component(&self) -> Option<func::ComponentFn> {
-        Some(self.sim.into())
+    fn init_engine(&self) -> Option<func::ComponentFn> {
+        Some(func::Gate::new(self.kind, self.bitsize, self.n_inputs).into())
     }
 
     fn component_name(&self) -> &'static str {
-        self.sim.kind().into()
+        self.kind.into()
     }
 
-    fn bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
+    fn init_bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
         // The origin is at the output port, which is at (4,2) in absolute coordinates.
         let bounds = [(-4, -2), (0, 2)];
-        let inputs = self.sim.n_inputs() as i32;
+        let inputs = i32::from(self.n_inputs);
         
         let mut ports = vec![];
         // Input ports
@@ -30,49 +33,54 @@ impl PhysicalComponent for Gate {
         ports.push((0, 0)); // Output port
 
         RelativeComponentBounds { bounds, ports }
+            .orient(self.orientation, Default::default())
     }
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 /// A NOT gate component.
 pub struct Not {
-    sim: func::Not,
+    bitsize: u8,
+    orientation: Orientation
 }
 
 impl PhysicalComponent for Not {
-    fn engine_component(&self) -> Option<func::ComponentFn> {
-        Some(self.sim.into())
+    fn init_engine(&self) -> Option<func::ComponentFn> {
+        Some(func::Not::new(self.bitsize).into())
     }
 
     fn component_name(&self) -> &'static str {
         "Not"
     }
 
-    fn bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
+    fn init_bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
         let origin = (3, 1);
         AbsoluteComponentBounds::new((3, 2), [(0, 1), origin])
             .into_relative(origin)
+            .orient(self.orientation, Default::default())
     }
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 /// A tri-state buffer.
 pub struct TriState {
-    sim: func::TriState,
+    bitsize: u8,
+    orientation: Orientation
 }
 
 impl PhysicalComponent for TriState {
-    fn engine_component(&self) -> Option<func::ComponentFn> {
-        Some(self.sim.into())
+    fn init_engine(&self) -> Option<func::ComponentFn> {
+        Some(func::TriState::new(self.bitsize).into())
     }
 
     fn component_name(&self) -> &'static str {
         "TriState"
     }
 
-    fn bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
+    fn init_bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
         let origin = (2, 1);
         AbsoluteComponentBounds::new((2, 2), [(0, 1), (1, 2), origin])
             .into_relative(origin)
+            .orient(self.orientation, Default::default())
     }
 }

--- a/packages/backend/src/middle_end/func/gates.rs
+++ b/packages/backend/src/middle_end/func/gates.rs
@@ -14,7 +14,7 @@ impl PhysicalComponent for Gate {
     }
 
     fn component_name(&self) -> &'static str {
-        self.sim.kind().name()
+        self.sim.kind().into()
     }
 
     fn bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {

--- a/packages/backend/src/middle_end/func/misc.rs
+++ b/packages/backend/src/middle_end/func/misc.rs
@@ -1,21 +1,21 @@
-use crate::engine::func;
+use crate::engine::{CircuitKey, func};
 use crate::middle_end::func::{PhysicalComponent, PhysicalInitContext, RelativeComponentBounds};
 
 /// A subcircuit component.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Subcircuit {
-    sim: func::Subcircuit
+    key: CircuitKey
 }
 impl PhysicalComponent for Subcircuit {
-    fn engine_component(&self) -> Option<func::ComponentFn> {
-        Some(self.sim.into())
+    fn init_engine(&self) -> Option<func::ComponentFn> {
+        Some(func::Subcircuit::new(self.key).into())
     }
 
     fn component_name(&self) ->  &'static str {
         "Subcircuit"
     }
 
-    fn bounds(&self, ctx: PhysicalInitContext<'_>) -> RelativeComponentBounds {
+    fn init_bounds(&self, ctx: PhysicalInitContext<'_>) -> RelativeComponentBounds {
         todo!()
     }
 }
@@ -24,7 +24,7 @@ impl PhysicalComponent for Subcircuit {
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Text;
 impl PhysicalComponent for Text {
-    fn engine_component(&self) -> Option<func::ComponentFn> {
+    fn init_engine(&self) -> Option<func::ComponentFn> {
         None
     }
 
@@ -32,7 +32,7 @@ impl PhysicalComponent for Text {
         "Text"
     }
 
-    fn bounds(&self, ctx: PhysicalInitContext<'_>) -> RelativeComponentBounds {
+    fn init_bounds(&self, ctx: PhysicalInitContext<'_>) -> RelativeComponentBounds {
         todo!()
     }
 }

--- a/packages/backend/src/middle_end/func/mod.rs
+++ b/packages/backend/src/middle_end/func/mod.rs
@@ -86,22 +86,27 @@ pub struct PhysicalInitContext<'a> {
 /// A component that can be added in a [middle-end circuit](`crate::middle_end::MiddleRepr`).
 #[enum_dispatch]
 pub trait PhysicalComponent {
-    /// A component which represents the engine logic of this component.
+    /// Initializes the component which represents the engine logic of this physical component,
+    /// based on the properties of the physical component.
     /// 
     /// This can be `None` if this component has no engine logic.
-    fn engine_component(&self) -> Option<ComponentFn>;
+    fn init_engine(&self) -> Option<ComponentFn>;
 
     /// The name of the component.
     fn component_name(&self) -> &'static str;
 
-    /// The area taken by this component, which includes:
-    ///   - The bounds of the component
+    /// Initializes the bounds of the physical component,
+    /// based on its properties.
+    /// 
+    /// The bounds are defined as:
+    ///   - The area encompassed of the component
+    ///     (defined by the top-leftmost point and the bottom-rightmost point)
     ///   - The position of the ports
     /// 
     /// These components are relative to the origin (0, 0),
     /// meaning that when placed, the locations are relative
     /// to the point the component is placed.
-    fn bounds(&self, ctx: PhysicalInitContext<'_>) -> RelativeComponentBounds;
+    fn init_bounds(&self, ctx: PhysicalInitContext<'_>) -> RelativeComponentBounds;
 }
 
 /// Struct containing the physical bounds of a component and location of ports.
@@ -156,7 +161,10 @@ impl RelativeComponentBounds {
             _ => Self::single_port(2 * MAX_COLS, height)
         }
     }
-    /// Orients the component bounds and ports according to the given orientation, assuming original orientation is East
+
+    /// Orients the component bounds and ports around the origin
+    /// in accordance to the specified orientation and handedness,
+    /// assuming the coordinates were originally oriented eastwards with down-right handedness.
     pub fn orient(self, orientation: Orientation, handedness: Handedness) -> Self {
         // Rotate bounds and ports, then get use the max and min of the corners to get new bounds:
         let Self { bounds: [b0, b1], ports } = self;
@@ -219,10 +227,10 @@ impl AbsoluteComponentBounds {
 
 #[enum_dispatch(PhysicalComponent)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum PhysicalComponentEnum {
     // Wiring
-    Input, Output, Constant, Splitter, Power, Ground, Tunnel, Probe,
+    Pin, Constant, Splitter, Power, Ground, Tunnel, Probe,
     // Muxes
     Mux, Demux, Decoder,
     // Misc

--- a/packages/backend/src/middle_end/func/mod.rs
+++ b/packages/backend/src/middle_end/func/mod.rs
@@ -73,8 +73,6 @@ pub enum Handedness {
     DownRight
 }
 
-
-
 /// Context available during [`PhysicalComponent`] initialization.
 pub struct PhysicalInitContext<'a> {
     /// The circuit this component is being placed in.
@@ -226,8 +224,13 @@ impl AbsoluteComponentBounds {
 }
 
 #[enum_dispatch(PhysicalComponent)]
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, strum::EnumDiscriminants, strum::IntoStaticStr)]
 #[expect(missing_docs)]
+#[strum_discriminants(
+    name(PhysicalComponentKind),
+    expect(missing_docs),
+    derive(strum::IntoStaticStr)
+)]
 pub enum PhysicalComponentEnum {
     // Wiring
     Pin, Constant, Splitter, Power, Ground, Tunnel, Probe,

--- a/packages/backend/src/middle_end/func/muxes.rs
+++ b/packages/backend/src/middle_end/func/muxes.rs
@@ -1,24 +1,27 @@
 use crate::engine::func::{self, ComponentFn};
-use crate::middle_end::func::{AbsoluteComponentBounds, PhysicalComponent, PhysicalInitContext, RelativeComponentBounds};
+use crate::middle_end::func::{AbsoluteComponentBounds, Handedness, Orientation, PhysicalComponent, PhysicalInitContext, RelativeComponentBounds};
 
 const PLEXER_WIDTH: u32 = 3;
 
 /// A multiplexer (mux) component.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Mux {
-    sim: func::Mux
+    bitsize: u8,
+    selsize: u8,
+    orientation: Orientation,
+    handedness: Handedness
 }
 impl PhysicalComponent for Mux {
-    fn engine_component(&self) -> Option<ComponentFn> {
-        Some(self.sim.into())
+    fn init_engine(&self) -> Option<ComponentFn> {
+        Some(func::Mux::new(self.bitsize, self.selsize).into())
     }
 
     fn component_name(&self) ->  &'static str {
         "Mux"
     }
 
-    fn bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
-        let n_inputs: u32 = self.sim.n_inputs() as u32;
+    fn init_bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
+        let n_inputs: u32 = func::Mux::n_inputs_from(self.selsize) as u32;
         
         let width = PLEXER_WIDTH;
         let height = 2 * n_inputs;
@@ -31,25 +34,29 @@ impl PhysicalComponent for Mux {
 
         AbsoluteComponentBounds::new((width, height), ports)
             .into_relative(origin)
+            .orient(self.orientation, self.handedness)
     }
 }
 
 /// A demultiplexer (demux) component.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Demux {
-    sim: func::Demux
+    bitsize: u8,
+    selsize: u8,
+    orientation: Orientation,
+    handedness: Handedness
 }
 impl PhysicalComponent for Demux {
-    fn engine_component(&self) -> Option<ComponentFn> {
-        Some(self.sim.into())
+    fn init_engine(&self) -> Option<ComponentFn> {
+        Some(func::Demux::new(self.bitsize, self.selsize).into())
     }
 
     fn component_name(&self) ->  &'static str {
         "Demux"
     }
 
-    fn bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
-        let n_outputs = self.sim.n_outputs() as u32;
+    fn init_bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
+        let n_outputs = func::Demux::n_outputs_from(self.selsize) as u32;
         
         let width = PLEXER_WIDTH;
         let height = 2 * n_outputs;
@@ -60,25 +67,28 @@ impl PhysicalComponent for Demux {
 
         AbsoluteComponentBounds::new((width, height), ports)
             .into_relative(origin)
+            .orient(self.orientation, self.handedness)
     }
 }
 
 /// A decoder component.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Decoder {
-    sim: func::Decoder
+    selsize: u8,
+    orientation: Orientation,
+    handedness: Handedness
 }
 impl PhysicalComponent for Decoder {
-    fn engine_component(&self) -> Option<ComponentFn> {
-        Some(self.sim.into())
+    fn init_engine(&self) -> Option<ComponentFn> {
+        Some(func::Decoder::new(self.selsize).into())
     }
 
     fn component_name(&self) ->  &'static str {
         "Decoder"
     }
 
-    fn bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
-        let n_outputs = self.sim.n_outputs() as u32;
+    fn init_bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
+        let n_outputs = func::Decoder::n_outputs_from(self.selsize) as u32;
         
         let width = PLEXER_WIDTH;
         let height = 2 * n_outputs;
@@ -89,5 +99,6 @@ impl PhysicalComponent for Decoder {
 
         AbsoluteComponentBounds::new((width, height), ports)
             .into_relative(origin)
+            .orient(self.orientation, self.handedness)
     }
 }

--- a/packages/backend/src/middle_end/func/wiring.rs
+++ b/packages/backend/src/middle_end/func/wiring.rs
@@ -1,61 +1,54 @@
+use crate::bitarray::BitArray;
 use crate::engine::func;
 use crate::bitarr;
-use crate::middle_end::func::{PhysicalComponent, PhysicalInitContext, RelativeComponentBounds};
+use crate::middle_end::func::{Handedness, Orientation, PhysicalComponent, PhysicalInitContext, RelativeComponentBounds};
 
 /// An input.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
-pub struct Input {
-    sim: func::Input
+pub struct Pin {
+    bitsize: u8,
+    is_input: bool,
+    orientation: Orientation
 }
-impl PhysicalComponent for Input {
-    fn engine_component(&self) -> Option<func::ComponentFn> {
-        Some(self.sim.into())
+impl PhysicalComponent for Pin {
+    fn init_engine(&self) -> Option<func::ComponentFn> {
+        Some(match self.is_input {
+            true  => func::Input::new(self.bitsize).into(),
+            false => func::Output::new(self.bitsize).into()
+        })
     }
 
     fn component_name(&self) -> &'static str {
-        "Input"
+        match self.is_input {
+            true  => "Input",
+            false => "Output"
+        }
     }
 
-    fn bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
-        RelativeComponentBounds::single_port_from_bitsize(self.sim.get_bitsize())
-    }
-}
-
-/// An output.
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
-pub struct Output {
-    sim: func::Output
-}
-impl PhysicalComponent for Output {
-    fn engine_component(&self) -> Option<func::ComponentFn> {
-        Some(self.sim.into())
-    }
-
-    fn component_name(&self) -> &'static str {
-        "Output"
-    }
-
-    fn bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
-        RelativeComponentBounds::single_port_from_bitsize(self.sim.get_bitsize())
+    fn init_bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
+        RelativeComponentBounds::single_port_from_bitsize(self.bitsize)
+            .orient(self.orientation, Default::default())
     }
 }
 
 /// A constant.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Constant {
-    sim: func::Constant
+    value: BitArray,
+    orientation: Orientation
 }
 impl PhysicalComponent for Constant {
-    fn engine_component(&self) -> Option<func::ComponentFn> {
-        Some(self.sim.into())
+    fn init_engine(&self) -> Option<func::ComponentFn> {
+        Some(func::Constant::new(self.value).into())
     }
 
     fn component_name(&self) -> &'static str {
         "Constant"
     }
 
-    fn bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
-        RelativeComponentBounds::single_port_from_bitsize(self.sim.get_value().len())
+    fn init_bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
+        RelativeComponentBounds::single_port_from_bitsize(self.value.len())
+            .orient(self.orientation, Default::default())
     }
 }
 
@@ -63,7 +56,7 @@ impl PhysicalComponent for Constant {
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Power;
 impl PhysicalComponent for Power {
-    fn engine_component(&self) -> Option<func::ComponentFn> {
+    fn init_engine(&self) -> Option<func::ComponentFn> {
         Some(func::Constant::new(bitarr![1]).into())
     }
 
@@ -71,7 +64,7 @@ impl PhysicalComponent for Power {
         "Power"
     }
 
-    fn bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
+    fn init_bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
         RelativeComponentBounds::single_port_with_origin(2, 3, (1, 3))
     }
 }
@@ -80,7 +73,7 @@ impl PhysicalComponent for Power {
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Ground;
 impl PhysicalComponent for Ground {
-    fn engine_component(&self) -> Option<func::ComponentFn> {
+    fn init_engine(&self) -> Option<func::ComponentFn> {
         Some(func::Constant::new(bitarr![0]).into())
     }
 
@@ -88,7 +81,7 @@ impl PhysicalComponent for Ground {
         "Ground"
     }
 
-    fn bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
+    fn init_bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
         RelativeComponentBounds::single_port_with_origin(2, 3, (1, 0))
     }
 }
@@ -96,31 +89,36 @@ impl PhysicalComponent for Ground {
 /// A splitter component.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Splitter {
-    sim: func::Splitter
+    bitsize: u8,
+    orientation: Orientation,
+    handedness: Handedness
 }
 impl PhysicalComponent for Splitter {
-    fn engine_component(&self) -> Option<func::ComponentFn> {
-        Some(self.sim.into())
+    fn init_engine(&self) -> Option<func::ComponentFn> {
+        Some(func::Splitter::new(self.bitsize).into())
     }
 
     fn component_name(&self) -> &'static str {
         "Splitter"
     }
 
-    fn bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
-        let bitsize = i32::from(self.sim.get_bitsize());
+    fn init_bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
+        let bitsize = i32::from(self.bitsize);
         let mut ports = vec![(0, 0)];
         ports.extend((1..=bitsize).map(|i| (2 * i, 2)));
 
         RelativeComponentBounds::new((bitsize * 2, 2), ports)
+            .orient(self.orientation, self.handedness)
     }
 }
 
 /// A tunnel.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
-pub struct Tunnel;
+pub struct Tunnel {
+    orientation: Orientation
+}
 impl PhysicalComponent for Tunnel {
-    fn engine_component(&self) -> Option<func::ComponentFn> {
+    fn init_engine(&self) -> Option<func::ComponentFn> {
         None
     }
 
@@ -128,16 +126,19 @@ impl PhysicalComponent for Tunnel {
         "Tunnel"
     }
 
-    fn bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
+    fn init_bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
         RelativeComponentBounds::single_port_with_origin(3, 2, (3, 1))
+            .orient(self.orientation, Default::default())
     }
 }
 
 /// A probe.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
-pub struct Probe;
+pub struct Probe {
+    orientation: Orientation
+}
 impl PhysicalComponent for Probe {
-    fn engine_component(&self) -> Option<func::ComponentFn> {
+    fn init_engine(&self) -> Option<func::ComponentFn> {
         None
     }
 
@@ -145,8 +146,9 @@ impl PhysicalComponent for Probe {
         "Probe"
     }
 
-    fn bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
+    fn init_bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
         RelativeComponentBounds::single_port(2, 2)
+            .orient(self.orientation, Default::default())
     }
 }
 

--- a/packages/backend/src/middle_end/mod.rs
+++ b/packages/backend/src/middle_end/mod.rs
@@ -39,6 +39,7 @@ pub struct MiddleRepr {
 ///   including their locations and properties.
 #[derive(Debug, Default)]
 struct CircuitArea {
+    name: String,
     components: SecondaryMap<FunctionKey, ComponentProps>,
     ui_components: SlotMap<UIKey, ComponentProps>,
     wires: WireSet,
@@ -92,11 +93,18 @@ impl MiddleRepr {
         Self::default()
     }
     /// Creates a new subcircuit.
-    pub fn add_circuit(&mut self) -> CircuitKey {
+    pub fn add_circuit(&mut self, name: &str) -> CircuitKey {
         let ck = self.engine.add_circuit();
-        self.physical.insert(ck, CircuitArea::default());
+
+        let area = CircuitArea {
+            name: name.to_string(),
+            ..Default::default()
+        };
+        self.physical.insert(ck, area);
+
         ck
     }
+
     /// Creates a mutable view for a given subcircuit.
     pub fn circuit(&mut self, key: CircuitKey) -> MiddleCircuit<'_> {
         MiddleCircuit { repr: self, key }

--- a/packages/backend/src/middle_end/mod.rs
+++ b/packages/backend/src/middle_end/mod.rs
@@ -6,6 +6,7 @@
 //! 
 
 use slotmap::{SecondaryMap, SlotMap};
+use thiserror::Error;
 
 use crate::engine::{CircuitForest, CircuitKey, FunctionKey, FunctionPort};
 use crate::middle_end::func::{ComponentBounds, PhysicalComponent, PhysicalComponentEnum, PhysicalInitContext};
@@ -58,15 +59,22 @@ struct ComponentProps {
     extra: PhysicalComponentEnum
 }
 
+#[derive(Debug, Error)]
 /// Errors which can occur when editing a middle-end circuit.
 pub enum ReprEditErr {
-    /// Adding a component fails.
-    CannotAddComponent,
-    /// Removing a component fails.
-    CannotRemoveComponent,
+    /// Component is out of bounds (so it cannot be added).
+    #[error("component is out of bounds")]
+    ComponentOutOfBounds,
+    
+    /// Component being specified doesn't exist (so it cannot be removed).
+    #[error("component does not exist")]
+    ComponentDoesNotExist,
+
     /// Adding a wire fails.
+    #[error("cannot add wire")]
     CannotAddWire,
     /// Removing a wire fails.
+    #[error("cannot remove wire")]
     CannotRemoveWire,
 }
 
@@ -102,13 +110,13 @@ impl MiddleCircuit<'_> {
     /// Adds a component to the circuit.
     /// 
     /// This takes the component, label, and location for the component.
-    /// This returns [`ReprEditErr::CannotAddComponent`] if it fails, which can occur if the component would be out of bounds. Otherwise, return the component key associated with added component.
+    /// This returns [`ReprEditErr::ComponentOutOfBounds`] if it fails, which can occur if the component would be out of bounds. Otherwise, return the component key associated with added component.
     pub fn add_component<C: Into<PhysicalComponentEnum>>(&mut self, physical: C, label: &str, pos: Coord) -> Result<ComponentKey, ReprEditErr> {
         let ctx = PhysicalInitContext { circuit: self, label };
         let physical = physical.into();
         let ComponentBounds { bounds, ports } = physical.init_bounds(ctx)
             .into_absolute(pos)
-            .ok_or(ReprEditErr::CannotAddComponent)?;
+            .ok_or(ReprEditErr::ComponentOutOfBounds)?;
         let props = ComponentProps {
             label: label.to_string(),
             origin: pos,
@@ -150,12 +158,12 @@ impl MiddleCircuit<'_> {
 
     /// Removes a component from the circuit.
     /// 
-    /// This returns [`ReprEditErr::CannotRemoveComponent`] if the component does not exist.
+    /// This returns [`ReprEditErr::ComponentDoesNotExist`] if the component does not exist.
     pub fn remove_component(&mut self, key: ComponentKey) -> Result<(), ReprEditErr> {
         let props = match key {
             ComponentKey::Function(gate) => circ!(self.physical).components.remove(gate),
             ComponentKey::UI(key) => circ!(self.physical).ui_components.remove(key),
-        }.ok_or(ReprEditErr::CannotRemoveComponent)?;
+        }.ok_or(ReprEditErr::ComponentDoesNotExist)?;
 
         // Remove from engine (if applicable):
         if let ComponentKey::Function(gate) = key {

--- a/packages/backend/src/middle_end/mod.rs
+++ b/packages/backend/src/middle_end/mod.rs
@@ -9,7 +9,7 @@ use slotmap::{SecondaryMap, SlotMap};
 use thiserror::Error;
 
 use crate::engine::{CircuitForest, CircuitKey, FunctionKey, FunctionPort};
-use crate::middle_end::func::{ComponentBounds, PhysicalComponent, PhysicalComponentEnum, PhysicalInitContext};
+use crate::middle_end::func::{ComponentBounds, Orientation, PhysicalComponent, PhysicalComponentEnum, PhysicalInitContext};
 use crate::middle_end::string_interner::StringInterner;
 use crate::middle_end::wire::{Wire, WireSet};
 
@@ -49,14 +49,15 @@ struct CircuitArea {
 #[derive(Debug)]
 struct ComponentProps {
     label: String,
+    label_location: Orientation,
 
     // Position
     origin: Coord,
     bounds: [Coord; 2],
     ports: Vec<Coord>,
 
-    // Extra props
-    extra: PhysicalComponentEnum
+    // Component-specific props
+    inner: PhysicalComponentEnum
 }
 
 #[derive(Debug, Error)]
@@ -90,6 +91,12 @@ impl MiddleRepr {
     pub fn new() -> Self {
         Self::default()
     }
+    /// Creates a new subcircuit.
+    pub fn add_circuit(&mut self) -> CircuitKey {
+        let ck = self.engine.add_circuit();
+        self.physical.insert(ck, CircuitArea::default());
+        ck
+    }
     /// Creates a mutable view for a given subcircuit.
     pub fn circuit(&mut self, key: CircuitKey) -> MiddleCircuit<'_> {
         MiddleCircuit { repr: self, key }
@@ -119,10 +126,11 @@ impl MiddleCircuit<'_> {
             .ok_or(ReprEditErr::ComponentOutOfBounds)?;
         let props = ComponentProps {
             label: label.to_string(),
+            label_location: Orientation::North,
             origin: pos,
             bounds,
             ports,
-            extra: physical,
+            inner: physical,
         };
 
         if let Some(component) = physical.init_engine() {
@@ -144,7 +152,7 @@ impl MiddleCircuit<'_> {
             // ~~~ UI component ~~~
 
             // Add tunnel to wire set:
-            if !props.label.is_empty() && matches!(props.extra, PhysicalComponentEnum::Tunnel(_)) {
+            if !props.label.is_empty() && matches!(props.inner, PhysicalComponentEnum::Tunnel(_)) {
                 let &[coord] = props.ports.as_slice() else { unreachable!("Tunnel should have 1 port") };
                 let sym = circ!(self.physical).tunnel_interner.add_ref(&props.label);
                 circ!(self.physical).wires.add_tunnel(coord, sym, || circ!(self.engine).add_value_node());
@@ -172,7 +180,7 @@ impl MiddleCircuit<'_> {
         }
         
         // Handle tunnels specially:
-        if matches!(props.extra, PhysicalComponentEnum::Tunnel(_)) {
+        if matches!(props.inner, PhysicalComponentEnum::Tunnel(_)) {
             let sym = circ!(self.physical).tunnel_interner.del_ref(&props.label)
                 .expect("Tunnel should have an assigned symbol");
             circ!(self.physical).wires.remove_tunnel(props.origin, sym)

--- a/packages/backend/src/middle_end/mod.rs
+++ b/packages/backend/src/middle_end/mod.rs
@@ -8,7 +8,7 @@
 use slotmap::{SecondaryMap, SlotMap};
 
 use crate::engine::{CircuitForest, CircuitKey, FunctionKey, FunctionPort};
-use crate::middle_end::func::{ComponentBounds, Handedness, Orientation, PhysicalComponent, PhysicalComponentEnum, PhysicalInitContext};
+use crate::middle_end::func::{ComponentBounds, PhysicalComponent, PhysicalComponentEnum, PhysicalInitContext};
 use crate::middle_end::string_interner::StringInterner;
 use crate::middle_end::wire::{Wire, WireSet};
 
@@ -53,8 +53,6 @@ struct ComponentProps {
     origin: Coord,
     bounds: [Coord; 2],
     ports: Vec<Coord>,
-    orientation: Orientation,
-    handedness: Handedness,
 
     // Extra props
     extra: PhysicalComponentEnum
@@ -108,19 +106,18 @@ impl MiddleCircuit<'_> {
     pub fn add_component<C: Into<PhysicalComponentEnum>>(&mut self, physical: C, label: &str, pos: Coord) -> Result<ComponentKey, ReprEditErr> {
         let ctx = PhysicalInitContext { circuit: self, label };
         let physical = physical.into();
-        let ComponentBounds { bounds, ports } = physical.bounds(ctx).into_absolute(pos)
+        let ComponentBounds { bounds, ports } = physical.init_bounds(ctx)
+            .into_absolute(pos)
             .ok_or(ReprEditErr::CannotAddComponent)?;
         let props = ComponentProps {
             label: label.to_string(),
             origin: pos,
             bounds,
             ports,
-            orientation: Default::default(),
-            handedness: Default::default(),
             extra: physical,
         };
 
-        if let Some(component) = physical.engine_component() {
+        if let Some(component) = physical.init_engine() {
             // ~~~ Engine component ~~~
             let gate = circ!(self.engine).add_function_node(component);
             
@@ -214,69 +211,6 @@ impl MiddleCircuit<'_> {
             .ok_or(ReprEditErr::CannotRemoveWire)?;
 
         self.handle_remove(result);
-
-        Ok(())
-    }
-    /// Sets the orientation of a component, and updates the circuit to accommodate the new orientation.
-    pub fn set_component_orientation(&mut self, key: ComponentKey, orientation: Orientation) -> Result<(), ReprEditErr> {
-        //Extract component properties
-        let props = match key {
-            ComponentKey::Function(gate) => circ!(self.physical).components.get_mut(gate)
-                .ok_or(ReprEditErr::CannotRemoveComponent)?,
-            ComponentKey::UI(ui_key) => circ!(self.physical).ui_components.get_mut(ui_key)
-                .ok_or(ReprEditErr::CannotRemoveComponent)?,
-        };
-        //extract properties that we will need to update:
-        let (label, origin, old_ports, physical, handedness) = (
-            props.label.clone(),
-            props.origin,
-            props.ports.clone(),
-            props.extra,
-            props.handedness,
-        );
-
-        // Get new bounds and ports: the extra property of props stores the physical component unaffected by orientation, so we can reuse it to get the new bounds and ports for the component with the new orientation.
-        let ComponentBounds { bounds, ports } = physical
-            .bounds(PhysicalInitContext { circuit: self, label: &label })
-            .orient(orientation, handedness)
-            .into_absolute(origin)
-            .ok_or(ReprEditErr::CannotAddComponent)?;
-
-        if !matches!(physical, PhysicalComponentEnum::Tunnel(_)) {
-            // Tunnel port is unaffected by orientation changes bc there is only one port, however for both ui and engine componets there are multiple ports whose positions are affected
-            for index in 0..old_ports.len() {
-                    let result = circ!(self.physical).wires.remove_port(key, index)
-                        .expect("Component removal should succeed");
-                    self.handle_remove(result);
-                }
-        } 
-            
-        
-        // Add new ports to wire set:
-        if let ComponentKey::Function(gate) = key {
-            for (index, &coord) in ports.iter().enumerate() {
-                let value = circ!(self.physical).wires.add_port(coord, key, index, || circ!(self.engine).add_value_node())
-                    .expect("Expected port addition to be successful");
-                circ!(self.engine).connect_one(value, FunctionPort { gate, index });
-            }
-        } 
-            // Update component properties:
-        match key {
-            ComponentKey::Function(gate) => {
-                let props = circ!(self.physical).components.get_mut(gate)
-                    .ok_or(ReprEditErr::CannotRemoveComponent)?;
-                props.bounds = bounds;
-                props.ports = ports;
-                props.orientation = orientation;
-            }
-            ComponentKey::UI(ui_key) => {
-                let props = circ!(self.physical).ui_components.get_mut(ui_key)
-                    .ok_or(ReprEditErr::CannotRemoveComponent)?;
-                props.bounds = bounds;
-                props.ports = ports;
-                props.orientation = orientation;
-            }
-        }
 
         Ok(())
     }

--- a/packages/backend/src/middle_end/mod.rs
+++ b/packages/backend/src/middle_end/mod.rs
@@ -126,7 +126,7 @@ impl MiddleCircuit<'_> {
     /// 
     /// This takes the component, label, and location for the component.
     /// This returns [`ReprEditErr::ComponentOutOfBounds`] if it fails, which can occur if the component would be out of bounds. Otherwise, return the component key associated with added component.
-    pub fn add_component<C: Into<PhysicalComponentEnum>>(&mut self, physical: C, label: &str, pos: Coord) -> Result<ComponentKey, ReprEditErr> {
+    pub fn add_component<C: Into<PhysicalComponentEnum>>(&mut self, physical: C, label: &str, label_location: Orientation, pos: Coord) -> Result<ComponentKey, ReprEditErr> {
         let ctx = PhysicalInitContext { circuit: self, label };
         let physical = physical.into();
         let ComponentBounds { bounds, ports } = physical.init_bounds(ctx)
@@ -134,7 +134,7 @@ impl MiddleCircuit<'_> {
             .ok_or(ReprEditErr::ComponentOutOfBounds)?;
         let props = ComponentProps {
             label: label.to_string(),
-            label_location: Orientation::North,
+            label_location,
             origin: pos,
             bounds,
             ports,

--- a/packages/backend/src/middle_end/serialize.rs
+++ b/packages/backend/src/middle_end/serialize.rs
@@ -3,16 +3,18 @@
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::{fmt, fs};
+use std::fs;
 
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
 use crate::middle_end::Wire;
 
 /// An error which can occur when serializing or deserializing a `.sim` file.
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum SerdeError {
     /// Error which occurs when reading a file.
+    #[error("failed to read .sim file '{}': {source}", path.display())]
     ReadFile {
         /// The path which was read.
         path: PathBuf,
@@ -20,37 +22,20 @@ pub enum SerdeError {
         source: std::io::Error,
     },
     /// Error which occurs when writing a file.
+    #[error("failed to write .sim file '{}': {source}", path.display())]
     WriteFile {
         /// The path which was written to.
         path: PathBuf,
         /// The error.
         source: std::io::Error,
     },
-    /// Error which occurs during file deserialization.
+    /// Error which occurs during file deserialization
+    #[error("failed to deserialize .sim JSON: {0}")]
     Deserialize(serde_json::Error),
     /// Error which occurs during file serialization.
+    #[error("failed to serialize .sim JSON: {0}")]
     Serialize(serde_json::Error),
 }
-
-impl fmt::Display for SerdeError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::ReadFile { path, source } => {
-                write!(f, "failed to read .sim file '{}': {source}", path.display())
-            }
-            Self::WriteFile { path, source } => {
-                write!(
-                    f,
-                    "failed to write .sim file '{}': {source}",
-                    path.display()
-                )
-            }
-            Self::Deserialize(source) => write!(f, "failed to deserialize .sim JSON: {source}"),
-            Self::Serialize(source) => write!(f, "failed to serialize .sim JSON: {source}"),
-        }
-    }
-}
-impl std::error::Error for SerdeError {}
 
 /// A serialized version of the middle-end representation,
 /// which is used when saving and loading from .sim files.

--- a/packages/backend/src/middle_end/wire/wire_set.rs
+++ b/packages/backend/src/middle_end/wire/wire_set.rs
@@ -440,6 +440,11 @@ impl WireSet {
     pub fn wires_at_coord(&self, c: Coord) -> impl Iterator<Item = Wire> {
         self.ranges.wires_at_coord(c)
     }
+
+    /// Gets all of the wires defined in the set.
+    pub fn wires(&self) -> impl Iterator<Item=Wire> {
+        self.ranges.wires()
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Implements scaffolding to facilitate middle-end serialization/deserialization. The key changes are:
- Adds `strum` and `thiserror` for simpler implementation of various items
- Restructures middle end component types to contain all their properties and renames the methods of the `PhysicalComponent` trait to account for that

Closes #7.

*Note: This PR previously added Clone to MiddleRepr, but that's not actually necessary for serialization/deserialization, and so it has been removed*