### PR TITLE
Bound certain middle repr. properties with ranged integers

### DIFF
--- a/packages/backend/src/bitarray.rs
+++ b/packages/backend/src/bitarray.rs
@@ -1,5 +1,10 @@
 //! Bit manipulation used for wires and bit values.
 
+mod ranged;
+pub(crate) use ranged::RangedByte;
+
+type BitSize = RangedByte<0, { u64::BITS as u8 }>;
+
 /// A `u64` bit mask of `len` 1s,
 /// useful for masking against values which
 /// should not affect [`BitArray`] comparisons.
@@ -248,7 +253,7 @@ pub struct BitArray {
     // Note that while this is implemented internally as LSB = index 0.
     data: u64,
     spec: u64,
-    len: u8
+    len: BitSize
 }
 
 /// Creates a [`BitState`].
@@ -309,7 +314,7 @@ impl BitArray {
     /// Any bits after index `(len - 1)` in `data` are ignored.
     /// The least-significant bit of `data` acts as index 0.
     pub fn from_bits(data: u64, len: u8) -> Self {
-        Self { data, spec: 0, len: len.clamp(BitArray::MIN_BITSIZE, BitArray::MAX_BITSIZE) }
+        Self { data, spec: 0, len: RangedByte::new_clamped(len) }
     }
 
     /// Creates a new array where the bit state is repeated `len` times.
@@ -318,17 +323,13 @@ impl BitArray {
         Self {
             data: stretch(data),
             spec: stretch(spec),
-            len: len.clamp(BitArray::MIN_BITSIZE, BitArray::MAX_BITSIZE)
+            len: RangedByte::new_clamped(len)
         }
     }
 
     /// The length of the array.
     pub const fn len(self) -> u8 {
-        match self.len {
-            ..BitArray::MIN_BITSIZE => BitArray::MIN_BITSIZE,
-            len @ BitArray::MIN_BITSIZE..BitArray::MAX_BITSIZE => len,
-            _ => BitArray::MAX_BITSIZE,
-        }
+        self.len.get()
     }
     /// Whether the array has no elements.
     pub fn is_empty(self) -> bool {
@@ -418,7 +419,7 @@ impl BitArray {
     /// If the new bitsize is larger than the current bitsize,
     /// it is extended with the specified array.
     pub fn resize(self, new_len: u8, fill: BitState) -> Self {
-        let new_len = new_len.clamp(BitArray::MIN_BITSIZE, BitArray::MAX_BITSIZE);
+        let new_len = BitSize::new_clamped(new_len);
         if new_len <= self.len() {
             // Truncation
             Self { data: self.data, spec: self.spec, len: new_len }
@@ -438,10 +439,44 @@ impl BitArray {
 
     /// Shifts the bitarray by the specified `shift`, using the applied `shift_type`.
     pub fn shift(self, shift: u32, shift_type: ShiftType) -> Self {
-        let data = shift_type.apply(self.data, self.len, shift);
-        let spec = shift_type.apply(self.spec, self.len, shift);
+        let data = shift_type.apply(self.data, self.len(), shift);
+        let spec = shift_type.apply(self.spec, self.len(), shift);
 
         Self { data, spec, len: self.len }
+    }
+
+    /// Pops the bitstate from the 0th index, removing it from the bitarray.
+    /// 
+    /// Returns None if BitArray is empty.
+    fn pop_front(&mut self) -> Option<BitState> {
+            let nl = self.len.decremented()?;
+            let raw = self.get_raw(0);
+            self.data >>= 1;
+            self.spec >>= 1;
+            self.len = nl;
+            Some(raw)
+    }
+
+    /// Pops the bitstate from the (len-1)th index, removing it from the bitarray.
+    /// 
+    /// Returns None if BitArray is empty.
+    fn pop_back(&mut self) -> Option<BitState> {
+        let nl = self.len.decremented()?;
+        self.len = nl;
+        Some(self.get_raw(nl.get()))
+    }
+
+    /// Pushes the bitstate to the end of the array (i.e., to the (len)th index).
+    /// 
+    /// Returns whether the push was successful.
+    fn push_back(&mut self, st: BitState) -> bool {
+        if let Some(nl) = self.len.incremented() {
+            self.set_raw(self.len(), st);
+            self.len = nl;
+            true
+        } else {
+            false
+        }
     }
 }
 impl FromIterator<BitState> for BitArray {
@@ -468,10 +503,9 @@ impl FromIterator<BitState> for BitArray {
     /// ```
     fn from_iter<I: IntoIterator<Item = BitState>>(iter: I) -> Self {
         iter.into_iter()
-            .zip(0..64)
-            .fold(BitArray::new(), |mut arr, (st, i)| {
-                arr.set_raw(i, st);
-                arr.len += 1;
+            .take(64)
+            .fold(BitArray::new(), |mut arr, st| {
+                assert!(arr.push_back(st));
                 arr
             })
     }
@@ -515,13 +549,7 @@ impl Iterator for BitArrayIntoIter {
     type Item = BitState;
 
     fn next(&mut self) -> Option<Self::Item> {
-        (!self.0.is_empty()).then(|| {
-            let raw = self.0.get_raw(0);
-            self.0.data >>= 1;
-            self.0.spec >>= 1;
-            self.0.len -= 1;
-            raw
-        })
+        self.0.pop_front()
     }
     fn size_hint(&self) -> (usize, Option<usize>) {
         let len = self.len();
@@ -530,16 +558,12 @@ impl Iterator for BitArrayIntoIter {
 }
 impl DoubleEndedIterator for BitArrayIntoIter {
     fn next_back(&mut self) -> Option<Self::Item> {
-        (!self.0.is_empty()).then(|| {
-            let raw = self.0.get_raw(self.0.len() - 1);
-            self.0.len -= 1;
-            raw
-        })
+        self.0.pop_back()
     }
 }
 impl ExactSizeIterator for BitArrayIntoIter {
     fn len(&self) -> usize {
-        usize::from(self.0.len())
+        usize::from(self.0.len)
     }
 }
 impl IntoIterator for BitArray {
@@ -616,14 +640,13 @@ impl BitArray {
         // 01 | 11 | 11 | 01 | 11
         // 10 | 00 | 01 | 10 | 11
         // 11 | 11 | 11 | 11 | 11
-        let len = self.len();
         let lz = self.is(BitState::Imped);
         let rz = rhs.is(BitState::Imped);
 
         let data = (!lz & !rz) | (lz & !rz & rhs.data) | (rz & self.data);
         let spec = (!lz & !rz) | (lz & !rz & rhs.spec) | (rz & self.spec);
         
-        Self { data, spec, len }
+        Self { data, spec, len: self.len }
     }
 
     pub(crate) fn short_circuits(self, occupied: u64) -> Option<u64> {
@@ -681,7 +704,7 @@ impl std::ops::BitAnd for BitArray {
 
         let data = !any_false;
         let spec = !any_false & !all_true;
-        let len = self.len();
+        let len = self.len;
         Self { spec, data, len }
     }
 }

--- a/packages/backend/src/bitarray/ranged.rs
+++ b/packages/backend/src/bitarray/ranged.rs
@@ -1,0 +1,104 @@
+/// A u8 which is restricted to the `MIN..=MAX` range.
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
+#[cfg_attr(feature="serde", derive(serde::Serialize), serde(transparent))]
+pub struct RangedByte<const MIN: u8, const MAX: u8>(u8);
+
+impl<const MIN: u8, const MAX: u8> RangedByte<MIN, MAX> {
+    /// Creates a new [`RangedByte`],
+    /// or returns None if value is out of bounds.
+    pub const fn new(n: u8) -> Option<Self> {
+        const { assert!(MIN <= MAX); }
+        if MIN <= n && n <= MAX {
+            Some(Self(n))
+        } else {
+            None
+        }
+    }
+    /// Creates a new [`RangedByte`],
+    /// clamping to the bounds if out of bounds.
+    pub fn new_clamped(n: u8) -> Self {
+        const { assert!(MIN <= MAX); }
+        Self(n.clamp(MIN, MAX))
+    }
+    /// Gets the value.
+    pub const fn get(self) -> u8 {
+        self.0
+    }
+
+    /// Increments value if result would stay in bound.
+    pub const fn incremented(self) -> Option<Self> {
+        match self.0 < MAX {
+            true => Some(Self(self.0 + 1)),
+            false => None
+        }
+    }
+    /// Decrements value if result would stay in bound.
+    pub const fn decremented(self) -> Option<Self> {
+        match self.0 > MIN {
+            true => Some(Self(self.0 - 1)),
+            false => None
+        }
+    }
+}
+
+impl<const MIN: u8, const MAX: u8> std::fmt::Debug for RangedByte<MIN, MAX> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+impl<const MIN: u8, const MAX: u8> std::fmt::Display for RangedByte<MIN, MAX> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl<const MIN: u8, const MAX: u8> PartialEq<u8> for RangedByte<MIN, MAX> {
+    fn eq(&self, other: &u8) -> bool {
+        self.0 == *other
+    }
+}
+impl<const MIN: u8, const MAX: u8> PartialOrd<u8> for RangedByte<MIN, MAX> {
+    fn partial_cmp(&self, other: &u8) -> Option<std::cmp::Ordering> {
+        Some(self.0.cmp(other))
+    }
+}
+impl<const MIN: u8, const MAX: u8> PartialEq<RangedByte<MIN, MAX>> for u8 {
+    fn eq(&self, other: &RangedByte<MIN, MAX>) -> bool {
+        *self == other.0
+    }
+}
+impl<const MIN: u8, const MAX: u8> PartialOrd<RangedByte<MIN, MAX>> for u8 {
+    fn partial_cmp(&self, other: &RangedByte<MIN, MAX>) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(&other.0))
+    }
+}
+impl<const MAX: u8> Default for RangedByte<0, MAX> {
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
+
+impl<const MIN: u8, const MAX: u8> From<RangedByte<MIN, MAX>> for u8 {
+    fn from(value: RangedByte<MIN, MAX>) -> Self {
+        value.get()
+    }
+}
+impl<const MIN: u8, const MAX: u8> From<RangedByte<MIN, MAX>> for usize {
+    fn from(value: RangedByte<MIN, MAX>) -> Self {
+        usize::from(value.get())
+    }
+}
+
+#[cfg(feature="serde")]
+impl<'de, const MIN: u8, const MAX: u8> serde::Deserialize<'de> for RangedByte<MIN, MAX> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where D: serde::Deserializer<'de>
+    {
+        let n = u8::deserialize(deserializer)?;
+        Self::new(n)
+            .ok_or_else(|| serde::de::Error::invalid_value(
+                serde::de::Unexpected::Unsigned(n.into()),
+                &&*format!("integer in {MIN}..={MAX}")
+            ))
+    }
+}

--- a/packages/backend/src/engine/func/arithmetic.rs
+++ b/packages/backend/src/engine/func/arithmetic.rs
@@ -3,7 +3,7 @@ use std::cmp::Ordering;
 use crate::bitarr;
 use crate::bitarray::{NotTwoValuedErr, ShiftType};
 use crate::engine::CircuitGraphMap;
-use crate::engine::func::{Component, PortProperties, PortType, PortUpdate, RunContext, port_list};
+use crate::engine::func::{BitSize, Component, PortProperties, PortType, PortUpdate, RunContext, port_list};
 use crate::{bitarray::BitArray, bitarray::BitState};
 
 /// Parses a set of inputs, returning the results of each port.
@@ -48,13 +48,13 @@ fn sign_extend_128(n: u128, bitsize: u8) -> i128 {
 /// An adder component.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Adder {
-    bitsize: u8
+    bitsize: BitSize
 }
 impl Adder {
     /// Creates a new instance of the Adder with specified bitsize.
     pub fn new(bitsize: u8) -> Self {
         Self {
-            bitsize: bitsize.clamp(BitArray::MIN_BITSIZE, BitArray::MAX_BITSIZE),
+            bitsize: BitSize::new_clamped(bitsize),
         }
     }
 }
@@ -62,13 +62,13 @@ impl Component for Adder {
     fn ports(&self, _: &CircuitGraphMap) -> Vec<PortProperties> {
         port_list(&[
             // inputs A and B for Adder
-            (PortProperties { ty: PortType::Input, bitsize: self.bitsize }, 2),
+            (PortProperties { ty: PortType::Input, bitsize: self.bitsize.get() }, 2),
             // Carry In Bit
             (PortProperties { ty: PortType::Input, bitsize: 1}, 1),
             // Carry Out Bit
             (PortProperties { ty: PortType::Output, bitsize: 1}, 1),
             // output
-            (PortProperties { ty: PortType::Output, bitsize: self.bitsize }, 1),
+            (PortProperties { ty: PortType::Output, bitsize: self.bitsize.get() }, 1),
         ])
     }
 
@@ -85,26 +85,26 @@ impl Component for Adder {
             Ok([Some(a), Some(b), cin]) => (a, b, cin),
             Ok(_) => return vec![
                 PortUpdate { index: 3, value: bitarr![Z] },
-                PortUpdate { index: 4, value: bitarr![Z; self.bitsize] },
+                PortUpdate { index: 4, value: bitarr![Z; self.bitsize.get()] },
             ],
             Err(_) => return vec![
                 PortUpdate { index: 3, value: bitarr![X] },
-                PortUpdate { index: 4, value: bitarr![X; self.bitsize] },
+                PortUpdate { index: 4, value: bitarr![X; self.bitsize.get()] },
             ]
         };
         let cin = cin.unwrap_or(0);
 
         let (sum, cout) = a.carrying_add(b, cin & 1 != 0);
-        match self.bitsize {
+        match self.bitsize.get() {
             64.. => vec![
                 PortUpdate { index: 3, value: BitArray::from(cout) },
                 PortUpdate { index: 4, value: BitArray::from(sum) }
             ],
             _ => {
-                let cout = sum & (1 << self.bitsize) != 0;
+                let cout = sum & (1 << self.bitsize.get()) != 0;
                 vec![
                     PortUpdate { index: 3, value: BitArray::from(cout) },
-                    PortUpdate { index: 4, value: BitArray::from_bits(sum, self.bitsize) }
+                    PortUpdate { index: 4, value: BitArray::from_bits(sum, self.bitsize.get()) }
                 ]
             }
         }
@@ -114,13 +114,13 @@ impl Component for Adder {
 /// A subtractor component.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Subtractor {
-    bitsize: u8
+    bitsize: BitSize
 }
 impl Subtractor {
     /// Creates a new instance of the Subtractor with specified bitsize.
     pub fn new(bitsize: u8) -> Self {
         Self {
-            bitsize: bitsize.clamp(BitArray::MIN_BITSIZE, BitArray::MAX_BITSIZE),
+            bitsize: BitSize::new_clamped(bitsize),
         }
     }
 }
@@ -128,13 +128,13 @@ impl Component for Subtractor {
     fn ports(&self, _: &CircuitGraphMap) -> Vec<PortProperties> {
         port_list(&[
             // inputs A and B for Subtractor
-            (PortProperties { ty: PortType::Input, bitsize: self.bitsize }, 2),
+            (PortProperties { ty: PortType::Input, bitsize: self.bitsize.get() }, 2),
             // Borrow In Bit
             (PortProperties { ty: PortType::Input, bitsize: 1}, 1),
             // Borrow Out Bit
             (PortProperties { ty: PortType::Output, bitsize: 1}, 1),
             // output
-            (PortProperties { ty: PortType::Output, bitsize: self.bitsize }, 1),
+            (PortProperties { ty: PortType::Output, bitsize: self.bitsize.get() }, 1),
         ])
     }
 
@@ -151,26 +151,26 @@ impl Component for Subtractor {
             Ok([Some(a), Some(b), bin]) => (a, b, bin),
             Ok(_) => return vec![
                 PortUpdate { index: 3, value: bitarr![Z] },
-                PortUpdate { index: 4, value: bitarr![Z; self.bitsize] },
+                PortUpdate { index: 4, value: bitarr![Z; self.bitsize.get()] },
             ],
             Err(_) => return vec![
                 PortUpdate { index: 3, value: bitarr![X] },
-                PortUpdate { index: 4, value: bitarr![X; self.bitsize] },
+                PortUpdate { index: 4, value: bitarr![X; self.bitsize.get()] },
             ]
         };
         let bin = bin.unwrap_or(0);
 
         let (diff, bout) = a.borrowing_sub(b, bin & 1 != 0);
-        match self.bitsize {
+        match self.bitsize.get() {
             64.. => vec![
                 PortUpdate { index: 3, value: BitArray::from(bout) },
                 PortUpdate { index: 4, value: BitArray::from(diff) }
             ],
             _ => {
-                let bout = diff & (1 << self.bitsize) != 0;
+                let bout = diff & (1 << self.bitsize.get()) != 0;
                 vec![
                     PortUpdate { index: 3, value: BitArray::from(bout) },
-                    PortUpdate { index: 4, value: BitArray::from_bits(diff, self.bitsize) }
+                    PortUpdate { index: 4, value: BitArray::from_bits(diff, self.bitsize.get()) }
                 ]
             }
         }
@@ -181,14 +181,14 @@ impl Component for Subtractor {
 /// A multiplier component.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Multiplier {
-    bitsize: u8,
+    bitsize: BitSize,
     signedness: SignType
 }
 impl Multiplier {
     /// Creates a new instance of the Multiplier with specified bitsize.
     pub fn new(bitsize: u8, signedness: SignType) -> Self {
         Self {
-            bitsize: bitsize.clamp(BitArray::MIN_BITSIZE, BitArray::MAX_BITSIZE),
+            bitsize: BitSize::new_clamped(bitsize),
             signedness
         }
     }
@@ -204,9 +204,9 @@ impl Component for Multiplier {
                 [4] = Carry Out / Upper Bits
              */
             // Inputs
-            (PortProperties { ty: PortType::Input, bitsize: self.bitsize }, 3),
+            (PortProperties { ty: PortType::Input, bitsize: self.bitsize.get() }, 3),
             // Outputs
-            (PortProperties { ty: PortType::Output, bitsize: self.bitsize }, 2),
+            (PortProperties { ty: PortType::Output, bitsize: self.bitsize.get() }, 2),
         ])
     }
 
@@ -222,17 +222,17 @@ impl Component for Multiplier {
         let (a, b, cin) = match parse_args(ctx.new_ports) {
             Ok([Some(a), Some(b), cin]) => (a, b, cin),
             Ok(_) => return vec![
-                PortUpdate { index: 3, value: bitarr![Z; self.bitsize] },
-                PortUpdate { index: 4, value: bitarr![Z; self.bitsize] },
+                PortUpdate { index: 3, value: bitarr![Z; self.bitsize.get()] },
+                PortUpdate { index: 4, value: bitarr![Z; self.bitsize.get()] },
             ],
             Err(_) => return vec![
-                PortUpdate { index: 3, value: bitarr![X; self.bitsize] },
-                PortUpdate { index: 4, value: bitarr![X; self.bitsize] },
+                PortUpdate { index: 3, value: bitarr![X; self.bitsize.get()] },
+                PortUpdate { index: 4, value: bitarr![X; self.bitsize.get()] },
             ]
         };
         let cin = cin.unwrap_or(0);
 
-        match (self.bitsize, self.signedness) {
+        match (self.bitsize.get(), self.signedness) {
             (64.., SignType::Unsigned) => {
                 let (prod, cout) = a.carrying_mul(b, cin);
                 vec![
@@ -243,26 +243,26 @@ impl Component for Multiplier {
             (..64, SignType::Unsigned) => {
                 let (prod_lo, prod_hi) = a.carrying_mul(b, cin);
                 let full_prod = (u128::from(prod_hi) << 64) | u128::from(prod_lo);
-                let mask = (1u128 << self.bitsize) - 1;
+                let mask = (1u128 << self.bitsize.get()) - 1;
 
                 let prod = (full_prod & mask) as u64;
-                let cout = ((full_prod >> self.bitsize) & mask) as u64;
+                let cout = ((full_prod >> self.bitsize.get()) & mask) as u64;
                 vec![
-                    PortUpdate { index: 3, value: BitArray::from_bits(prod, self.bitsize) },
-                    PortUpdate { index: 4, value: BitArray::from_bits(cout, self.bitsize) },
+                    PortUpdate { index: 3, value: BitArray::from_bits(prod, self.bitsize.get()) },
+                    PortUpdate { index: 4, value: BitArray::from_bits(cout, self.bitsize.get()) },
                 ]
             },
             (_, SignType::TwosComplement) => {
-                let full_prod = sign_extend_128(u128::from(a), self.bitsize)
-                    .wrapping_mul(sign_extend_128(u128::from(b), self.bitsize))
-                    .wrapping_add(sign_extend_128(u128::from(cin), self.bitsize));
-                let mask = (1i128 << self.bitsize) - 1;
+                let full_prod = sign_extend_128(u128::from(a), self.bitsize.get())
+                    .wrapping_mul(sign_extend_128(u128::from(b), self.bitsize.get()))
+                    .wrapping_add(sign_extend_128(u128::from(cin), self.bitsize.get()));
+                let mask = (1i128 << self.bitsize.get()) - 1;
 
                 let prod = (full_prod & mask) as u64;
-                let cout = ((full_prod >> self.bitsize) & mask) as u64;
+                let cout = ((full_prod >> self.bitsize.get()) & mask) as u64;
                 vec![
-                    PortUpdate { index: 3, value: BitArray::from_bits(prod, self.bitsize) },
-                    PortUpdate { index: 4, value: BitArray::from_bits(cout, self.bitsize) },
+                    PortUpdate { index: 3, value: BitArray::from_bits(prod, self.bitsize.get()) },
+                    PortUpdate { index: 4, value: BitArray::from_bits(cout, self.bitsize.get()) },
                 ]
             }
         }
@@ -272,14 +272,14 @@ impl Component for Multiplier {
 /// A Divider component.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Divider {
-    bitsize: u8,
+    bitsize: BitSize,
     signedness: SignType
 }
 impl Divider {
     /// Creates a new instance of the Divider with specified bitsize.
     pub fn new(bitsize: u8, signedness: SignType) -> Self {
         Self {
-            bitsize: bitsize.clamp(BitArray::MIN_BITSIZE, BitArray::MAX_BITSIZE),
+            bitsize: BitSize::new_clamped(bitsize),
             signedness
         }
     }
@@ -295,9 +295,9 @@ impl Component for Divider {
                 [4] = Remainder
              */
             // Inputs
-            (PortProperties { ty: PortType::Input, bitsize: self.bitsize }, 3),
+            (PortProperties { ty: PortType::Input, bitsize: self.bitsize.get() }, 3),
             // Outputs
-            (PortProperties { ty: PortType::Input, bitsize: self.bitsize }, 2),
+            (PortProperties { ty: PortType::Input, bitsize: self.bitsize.get() }, 2),
         ])
     }
 
@@ -312,49 +312,49 @@ impl Component for Divider {
         let (a_lo, b, a_hi) = match parse_args(ctx.new_ports) {
             Ok([Some(a), Some(b), cin]) => (a, b, cin),
             Ok(_) => return vec![
-                PortUpdate { index: 3, value: bitarr![Z; self.bitsize] },
-                PortUpdate { index: 4, value: bitarr![Z; self.bitsize] },
+                PortUpdate { index: 3, value: bitarr![Z; self.bitsize.get()] },
+                PortUpdate { index: 4, value: bitarr![Z; self.bitsize.get()] },
             ],
             Err(_) => return vec![
-                PortUpdate { index: 3, value: bitarr![X; self.bitsize] },
-                PortUpdate { index: 4, value: bitarr![X; self.bitsize] },
+                PortUpdate { index: 3, value: bitarr![X; self.bitsize.get()] },
+                PortUpdate { index: 4, value: bitarr![X; self.bitsize.get()] },
             ]
         };
         match (b, self.signedness) {
             // Div by zero, just let it be div by 1
             (0, _) => {
                 vec![
-                    PortUpdate { index: 3, value: BitArray::from_bits(a_lo, self.bitsize) },
-                    PortUpdate { index: 4, value: BitArray::from_bits(0, self.bitsize) },
+                    PortUpdate { index: 3, value: BitArray::from_bits(a_lo, self.bitsize.get()) },
+                    PortUpdate { index: 4, value: BitArray::from_bits(0, self.bitsize.get()) },
                 ]
             }
             (_, SignType::Unsigned) => {
                 let a_hi = a_hi.unwrap_or(0); // ZEXT
-                let a = (u128::from(a_hi) << self.bitsize) | u128::from(a_lo);
+                let a = (u128::from(a_hi) << self.bitsize.get()) | u128::from(a_lo);
                 let b = u128::from(b);
 
                 vec![
-                    PortUpdate { index: 3, value: BitArray::from_bits((a / b) as u64, self.bitsize) },
-                    PortUpdate { index: 4, value: BitArray::from_bits((a % b) as u64, self.bitsize) },
+                    PortUpdate { index: 3, value: BitArray::from_bits((a / b) as u64, self.bitsize.get()) },
+                    PortUpdate { index: 4, value: BitArray::from_bits((a % b) as u64, self.bitsize.get()) },
                 ]
             }
             (_, SignType::TwosComplement) => {
                 let sa = match a_hi {
                     // a_hi concat a_lo
                     Some(a_hi) => sign_extend_128({
-                       (u128::from(a_hi) << self.bitsize) | u128::from(a_lo)
-                    }, self.bitsize * 2),
+                       (u128::from(a_hi) << self.bitsize.get()) | u128::from(a_lo)
+                    }, self.bitsize.get() * 2),
 
                     // a_lo, sign extended
-                    None => sign_extend_128(u128::from(a_lo), self.bitsize),
+                    None => sign_extend_128(u128::from(a_lo), self.bitsize.get()),
                 };
-                let sb = sign_extend_128(u128::from(b), self.bitsize);
+                let sb = sign_extend_128(u128::from(b), self.bitsize.get());
 
                 let div = sa / sb;
                 let rem = sa % sb;
                 vec![
-                    PortUpdate { index: 3, value: BitArray::from_bits(div as u64, self.bitsize) },
-                    PortUpdate { index: 4, value: BitArray::from_bits(rem as u64, self.bitsize) },
+                    PortUpdate { index: 3, value: BitArray::from_bits(div as u64, self.bitsize.get()) },
+                    PortUpdate { index: 4, value: BitArray::from_bits(rem as u64, self.bitsize.get()) },
                 ]
             }
         }
@@ -364,13 +364,13 @@ impl Component for Divider {
 /// A negator component.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Negator {
-    bitsize: u8
+    bitsize: BitSize
 }
 impl Negator {
     /// Creates a new instance of the negator with specified bitsize.
     pub fn new(bitsize: u8) -> Self {
         Self {
-            bitsize: bitsize.clamp(BitArray::MIN_BITSIZE, BitArray::MAX_BITSIZE),
+            bitsize: BitSize::new_clamped(bitsize),
         }
     }
 }
@@ -378,9 +378,9 @@ impl Component for Negator {
     fn ports(&self, _: &CircuitGraphMap) -> Vec<PortProperties> {
         port_list(&[
             // Input
-            (PortProperties { ty: PortType::Input, bitsize: self.bitsize }, 1),
+            (PortProperties { ty: PortType::Input, bitsize: self.bitsize.get() }, 1),
             // Output
-            (PortProperties { ty: PortType::Output, bitsize: self.bitsize }, 1),
+            (PortProperties { ty: PortType::Output, bitsize: self.bitsize.get() }, 1),
         ])
     }
 
@@ -389,11 +389,11 @@ impl Component for Negator {
             Ok(val) => val,
             Err(e) => return vec![PortUpdate {
                 index: 1,
-                value: BitArray::repeat(e.bit_state(), self.bitsize)
+                value: BitArray::repeat(e.bit_state(), self.bitsize.get())
             }]
         };
 
-        let out = BitArray::from_bits(inp.wrapping_neg(), self.bitsize);
+        let out = BitArray::from_bits(inp.wrapping_neg(), self.bitsize.get());
         vec![PortUpdate { index: 1, value: out }]
     }
 }
@@ -410,7 +410,7 @@ pub enum SignType {
 /// A Comparator component.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Comparator {
-    bitsize: u8,
+    bitsize: BitSize,
     signedness: SignType
 
 }
@@ -418,7 +418,7 @@ impl Comparator {
     /// Creates a new instance of the comparator with specified bitsize.
     pub fn new(bitsize: u8, signedness: SignType) -> Self {
         Self {
-            bitsize: bitsize.clamp(BitArray::MIN_BITSIZE, BitArray::MAX_BITSIZE),
+            bitsize: BitSize::new_clamped(bitsize),
             signedness
         }
     }
@@ -427,7 +427,7 @@ impl Component for Comparator {
     fn ports(&self, _: &CircuitGraphMap) -> Vec<PortProperties> {
         port_list(&[
             // Input
-            (PortProperties { ty: PortType::Input, bitsize: self.bitsize }, 2),
+            (PortProperties { ty: PortType::Input, bitsize: self.bitsize.get() }, 2),
             /*
                 [2] = <
                 [3] = =
@@ -453,7 +453,7 @@ impl Component for Comparator {
         };
 
         let cmp = match self.signedness {
-            SignType::TwosComplement => sign_extend_64(a, self.bitsize).cmp(&sign_extend_64(b, self.bitsize)),
+            SignType::TwosComplement => sign_extend_64(a, self.bitsize.get()).cmp(&sign_extend_64(b, self.bitsize.get())),
             SignType::Unsigned => a.cmp(&b),
         };
         vec![
@@ -478,16 +478,16 @@ pub enum ExtensionType {
 /// A Bit-Extender component.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct BitExtender {
-    in_bitsize: u8,
-    out_bitsize: u8,
+    in_bitsize: BitSize,
+    out_bitsize: BitSize,
     ext_type: ExtensionType
 }
 impl BitExtender {
     /// Creates a new instance of the bitextender with specified bitsize.
-    pub fn new(in_bitsize: u8, out_bitsize:u8, ext_type: ExtensionType) -> Self {
+    pub fn new(in_bitsize: u8, out_bitsize: u8, ext_type: ExtensionType) -> Self {
         Self {
-            in_bitsize: in_bitsize.clamp(BitArray::MIN_BITSIZE, BitArray::MAX_BITSIZE),
-            out_bitsize: out_bitsize.clamp(BitArray::MIN_BITSIZE, BitArray::MAX_BITSIZE),
+            in_bitsize: BitSize::new_clamped(in_bitsize),
+            out_bitsize: BitSize::new_clamped(out_bitsize),
             ext_type
         }
     }
@@ -496,9 +496,9 @@ impl Component for BitExtender {
     fn ports(&self, _: &CircuitGraphMap) -> Vec<PortProperties> {
         port_list(&[
             // Input
-            (PortProperties { ty: PortType::Input, bitsize: self.in_bitsize}, 1),
+            (PortProperties { ty: PortType::Input, bitsize: self.in_bitsize.get() }, 1),
             // Output
-            (PortProperties { ty: PortType::Output, bitsize: self.out_bitsize }, 1),
+            (PortProperties { ty: PortType::Output, bitsize: self.out_bitsize.get() }, 1),
         ])
     }
 
@@ -508,7 +508,7 @@ impl Component for BitExtender {
             ExtensionType::One => BitState::High,
             ExtensionType::Sign => ctx.new_ports[0].get(ctx.new_ports[0].len() - 1).unwrap(),
         };
-        let value = ctx.new_ports[0].resize(self.out_bitsize, fill);
+        let value = ctx.new_ports[0].resize(self.out_bitsize.get(), fill);
 
         vec![PortUpdate { index: 1, value }]
     }
@@ -517,13 +517,13 @@ impl Component for BitExtender {
 /// A Shifter component.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Shifter {
-    bitsize: u8,
+    bitsize: BitSize,
     shift_type: ShiftType
 }
 impl Shifter {
     /// Creates a new instance of the Shifter with specified bitsize.
     pub fn new(bitsize: u8, shift_type: ShiftType) -> Self {
-        let bitsize = bitsize.clamp(BitArray::MIN_BITSIZE, BitArray::MAX_BITSIZE);
+        let bitsize = BitSize::new_clamped(bitsize);
         Self {
             bitsize,
             shift_type
@@ -534,7 +534,7 @@ impl Shifter {
     pub fn shift_bitsize(self) -> u8 {
         // ilog2 ceil
         // doesn't exist in stdlib so we're just gonna hardcode it lol
-        match self.bitsize {
+        match self.bitsize.get() {
             0..=2   => 1,
             3..=4   => 2,
             5..=8   => 3,
@@ -548,18 +548,18 @@ impl Component for Shifter {
     fn ports(&self, _: &CircuitGraphMap) -> Vec<PortProperties> {
         port_list(&[
             // Input
-            (PortProperties { ty: PortType::Input, bitsize: self.bitsize }, 1),
+            (PortProperties { ty: PortType::Input, bitsize: self.bitsize.get() }, 1),
             // Shift
             (PortProperties { ty: PortType::Input, bitsize: self.shift_bitsize() }, 1),
             // Output
-            (PortProperties { ty: PortType::Output, bitsize: self.bitsize }, 1),
+            (PortProperties { ty: PortType::Output, bitsize: self.bitsize.get() }, 1),
         ])
     }
 
     fn run_inner(&self, ctx: RunContext<'_>) -> Vec<PortUpdate> {
         let a = ctx.new_ports[0];
         let Ok(b) = u64::try_from(ctx.new_ports[1]) else {
-            return vec![PortUpdate { index: 2, value: bitarr![X; self.bitsize] }]
+            return vec![PortUpdate { index: 2, value: bitarr![X; self.bitsize.get()] }]
         };
         
         vec![PortUpdate { index: 2, value: a.shift(b as u32, self.shift_type) }]

--- a/packages/backend/src/engine/func/gates.rs
+++ b/packages/backend/src/engine/func/gates.rs
@@ -1,11 +1,13 @@
-use crate::bitarray::{BitArray, BitState, bitarr};
+use crate::bitarray::{BitArray, BitState, RangedByte, bitarr};
 use crate::engine::CircuitGraphMap;
-use crate::engine::func::{Component, PortProperties, PortType, PortUpdate, RunContext, port_list};
+use crate::engine::func::{BitSize, Component, PortProperties, PortType, PortUpdate, RunContext, port_list};
 
 /// Minimum number of inputs for multi-input logic gates.
 pub const MIN_GATE_INPUTS: u8 = 2;
 /// Maximum number of inputs for multi-input logic gates.
 pub const MAX_GATE_INPUTS: u8 = 64;
+
+pub(crate) type GateInputs = RangedByte<MIN_GATE_INPUTS, MAX_GATE_INPUTS>;
 
 /// The gate type for [`Gate`].
 /// 
@@ -36,16 +38,16 @@ impl GateKind {
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Gate {
     kind: GateKind,
-    bitsize: u8,
-    n_inputs: u8
+    bitsize: BitSize,
+    n_inputs: GateInputs
 }
 impl Gate {
     /// Creates a new instance of the gate with specified bitsize and number of inputs.
     pub fn new(kind: GateKind, bitsize: u8, n_inputs: u8) -> Self {
         Self {
             kind,
-            bitsize: bitsize.clamp(BitArray::MIN_BITSIZE, BitArray::MAX_BITSIZE),
-            n_inputs: n_inputs.clamp(MIN_GATE_INPUTS, MAX_GATE_INPUTS)
+            bitsize: BitSize::new_clamped(bitsize),
+            n_inputs: GateInputs::new_clamped(n_inputs)
         }
     }
 
@@ -55,27 +57,27 @@ impl Gate {
     }
     /// Returns the number of inputs for this gate.
     pub fn n_inputs(&self) -> u8 {
-        self.n_inputs
+        self.n_inputs.get()
     }
     /// Returns the bitsize for this gate.
     pub fn bitsize(&self) -> u8 {
-        self.bitsize
+        self.bitsize.get()
     }
 }
 impl Component for Gate {
     fn ports(&self, _: &CircuitGraphMap) -> Vec<PortProperties> {
         port_list(&[
             // inputs
-            (PortProperties { ty: PortType::Input, bitsize: self.bitsize }, usize::from(self.n_inputs)),
+            (PortProperties { ty: PortType::Input, bitsize: self.bitsize.get() }, usize::from(self.n_inputs)),
             // outputs
-            (PortProperties { ty: PortType::Output, bitsize: self.bitsize }, 1),
+            (PortProperties { ty: PortType::Output, bitsize: self.bitsize.get() }, 1),
         ])
     }
 
     fn run_inner(&self, ctx: RunContext<'_>) -> Vec<PortUpdate> {
         let inputs = ctx.new_ports[..usize::from(self.n_inputs)].iter().cloned();
         let output = self.kind.reduce(inputs)
-            .unwrap_or_else(|| bitarr![X; self.bitsize]);
+            .unwrap_or_else(|| bitarr![X; self.bitsize.get()]);
         
         vec![PortUpdate {
             index: usize::from(self.n_inputs),
@@ -87,13 +89,13 @@ impl Component for Gate {
 /// A NOT gate component.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Not {
-    bitsize: u8
+    bitsize: BitSize
 }
 impl Not {
     /// Creates a new instance of the NOT gate with specified bitsize.
     pub fn new(bitsize: u8) -> Self {
         Self {
-            bitsize: bitsize.clamp(BitArray::MIN_BITSIZE, BitArray::MAX_BITSIZE)
+            bitsize: BitSize::new_clamped(bitsize)
         }
     }
 }
@@ -101,9 +103,9 @@ impl Component for Not {
     fn ports(&self, _: &CircuitGraphMap) -> Vec<PortProperties> {
         port_list(&[
             // input
-            (PortProperties { ty: PortType::Input, bitsize: self.bitsize }, 1),
+            (PortProperties { ty: PortType::Input, bitsize: self.bitsize.get() }, 1),
             // output
-            (PortProperties { ty: PortType::Output, bitsize: self.bitsize }, 1),
+            (PortProperties { ty: PortType::Output, bitsize: self.bitsize.get() }, 1),
         ])
     }
 
@@ -116,13 +118,13 @@ impl Component for Not {
 /// A tri-state buffer component.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct TriState {
-    bitsize: u8
+    bitsize: BitSize
 }
 impl TriState {
     /// Creates a new instance of the tri-state buffer with specified bitsize.
     pub fn new(bitsize: u8) -> Self {
         Self {
-            bitsize: bitsize.clamp(BitArray::MIN_BITSIZE, BitArray::MAX_BITSIZE)
+            bitsize: BitSize::new_clamped(bitsize)
         }
     }
 }
@@ -132,9 +134,9 @@ impl Component for TriState {
             // selector
             (PortProperties { ty: PortType::Input, bitsize: 1 }, 1),
             // input
-            (PortProperties { ty: PortType::Input, bitsize: self.bitsize }, 1),
+            (PortProperties { ty: PortType::Input, bitsize: self.bitsize.get() }, 1),
             // output
-            (PortProperties { ty: PortType::Output, bitsize: self.bitsize }, 1),
+            (PortProperties { ty: PortType::Output, bitsize: self.bitsize.get() }, 1),
         ])
     }
 
@@ -142,8 +144,8 @@ impl Component for TriState {
         let gate = ctx.new_ports[0].index(0);
         let result = match gate {
             BitState::High => ctx.new_ports[1],
-            BitState::Low | BitState::Imped => bitarr![Z; self.bitsize],
-            BitState::Unk => bitarr![X; self.bitsize],
+            BitState::Low | BitState::Imped => bitarr![Z; self.bitsize.get()],
+            BitState::Unk => bitarr![X; self.bitsize.get()],
         };
         vec![PortUpdate { index: 2, value: result }]
     }

--- a/packages/backend/src/engine/func/memory.rs
+++ b/packages/backend/src/engine/func/memory.rs
@@ -1,18 +1,18 @@
 use crate::bitarr;
 use crate::bitarray::{BitArray, BitState};
 use crate::engine::CircuitGraphMap;
-use crate::engine::func::{Component, PortProperties, PortType, PortUpdate, RunContext, Sensitivity, port_list};
+use crate::engine::func::{BitSize, Component, PortProperties, PortType, PortUpdate, RunContext, Sensitivity, port_list};
 
 /// A register component.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Register {
-    bitsize: u8
+    bitsize: BitSize
 }
 impl Register {
     /// Creates a new instance of the Register with specified bitsize.
     pub fn new(bitsize: u8) -> Self {
         Self {
-            bitsize: bitsize.clamp(BitArray::MIN_BITSIZE, BitArray::MAX_BITSIZE)
+            bitsize: BitSize::new_clamped(bitsize)
         }
     }
 }
@@ -20,19 +20,19 @@ impl Component for Register {
     fn ports(&self, _: &CircuitGraphMap) -> Vec<PortProperties> {
         port_list(&[
             // din
-            (PortProperties { ty: PortType::Input, bitsize: self.bitsize }, 1),
+            (PortProperties { ty: PortType::Input, bitsize: self.bitsize.get() }, 1),
             // enable, clock, clear
             (PortProperties { ty: PortType::Input, bitsize: 1 }, 3),
             // dout
-            (PortProperties { ty: PortType::Output, bitsize: self.bitsize }, 1),
+            (PortProperties { ty: PortType::Output, bitsize: self.bitsize.get() }, 1),
         ])
     }
     fn initialize_port_state(&self, state: &mut [BitArray]) {
-        state[4] = bitarr![0; self.bitsize];
+        state[4] = bitarr![0; self.bitsize.get()];
     }
     fn run_inner(&self, ctx: RunContext<'_>) -> Vec<PortUpdate> {
         if ctx.new_ports[3].all(BitState::High) {
-            vec![PortUpdate { index: 4, value: bitarr![0; self.bitsize] }]
+            vec![PortUpdate { index: 4, value: bitarr![0; self.bitsize.get()] }]
         } else if Sensitivity::Posedge.activated(ctx.old_ports[2], ctx.new_ports[2]) && ctx.new_ports[1].all(BitState::High) {
             vec![PortUpdate { index: 4, value: ctx.new_ports[0] }]
         } else {

--- a/packages/backend/src/engine/func/mod.rs
+++ b/packages/backend/src/engine/func/mod.rs
@@ -9,7 +9,7 @@
 //! - **[`PortType`] and [`PortProperties`]**: Enumerations and structures to define the types and properties of ports for components.
 //! - **[`PortUpdate`]**: A structure representing updates to port values during simulation.
 //! - **Digital Logic Components**: Implementations of basic logic components used to simulate digital circuits.
-use crate::bitarray::{BitArray, BitState};
+use crate::bitarray::{BitArray, BitState, RangedByte};
 use crate::engine::CircuitGraphMap;
 use crate::engine::state::InnerFunctionState;
 
@@ -239,3 +239,5 @@ fn floating_ports(properties: &[PortProperties]) -> Vec<BitArray> {
         .map(|p| bitarr![Z; p.bitsize])
         .collect()
 }
+
+pub(crate) type BitSize = RangedByte<{ BitArray::MIN_BITSIZE }, { BitArray::MAX_BITSIZE }>;

--- a/packages/backend/src/engine/func/muxes.rs
+++ b/packages/backend/src/engine/func/muxes.rs
@@ -1,6 +1,7 @@
 
+use crate::bitarray::RangedByte;
 use crate::engine::CircuitGraphMap;
-use crate::engine::func::{Component, PortProperties, PortType, PortUpdate, RunContext, port_list};
+use crate::engine::func::{BitSize, Component, PortProperties, PortType, PortUpdate, RunContext, port_list};
 use crate::{bitarr, bitarray::BitArray};
 
 /// Minimum number of selector bits for Mux/Demux/Decoder.
@@ -8,23 +9,25 @@ pub const MIN_SELSIZE: u8 = 1;
 /// Maximum number of selector bits for Mux/Demux/Decoder.
 pub const MAX_SELSIZE: u8 = 6;
 
+pub(crate) type SelSize = RangedByte<{ MIN_SELSIZE }, { MAX_SELSIZE }>;
+
 /// A multiplexer (mux) component.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Mux {
-    bitsize: u8,
-    selsize: u8
+    bitsize: BitSize,
+    selsize: SelSize
 }
 impl Mux {
     /// Creates a new instance of the Mux with specified bitsize and selector size.
     pub fn new(bitsize: u8, selsize: u8) -> Self {
         Self {
-            bitsize: bitsize.clamp(BitArray::MIN_BITSIZE, BitArray::MAX_BITSIZE),
-            selsize: selsize.clamp(MIN_SELSIZE, MAX_SELSIZE)
+            bitsize: BitSize::new_clamped(bitsize),
+            selsize: SelSize::new_clamped(selsize)
         }
     }
 
-    pub(crate) fn n_inputs_from(selsize: u8) -> usize {
-        1 << selsize
+    pub(crate) fn n_inputs_from(selsize: SelSize) -> usize {
+        1 << selsize.get()
     }
     /// The number of inputs.
     pub fn n_inputs(self) -> usize {
@@ -35,11 +38,11 @@ impl Component for Mux {
     fn ports(&self, _: &CircuitGraphMap) -> Vec<PortProperties> {
         port_list(&[
             // selector
-            (PortProperties { ty: PortType::Input, bitsize: self.selsize }, 1),
+            (PortProperties { ty: PortType::Input, bitsize: self.selsize.get() }, 1),
             // inputs
-            (PortProperties { ty: PortType::Input, bitsize: self.bitsize }, self.n_inputs()),
+            (PortProperties { ty: PortType::Input, bitsize: self.bitsize.get() }, self.n_inputs()),
             // output
-            (PortProperties { ty: PortType::Output, bitsize: self.bitsize }, 1),
+            (PortProperties { ty: PortType::Output, bitsize: self.bitsize.get() }, 1),
         ])
     }
 
@@ -47,7 +50,7 @@ impl Component for Mux {
         let m_sel = u64::try_from(ctx.new_ports[0]);
         let result = match m_sel {
             Ok(sel) => ctx.new_ports[sel as usize + 1],
-            Err(e) => BitArray::repeat(e.bit_state(), self.bitsize),
+            Err(e) => BitArray::repeat(e.bit_state(), self.bitsize.get()),
         };
         vec![PortUpdate { index: 1 + self.n_inputs(), value: result }]
     }
@@ -56,20 +59,20 @@ impl Component for Mux {
 /// A demultiplexer (demux) component.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Demux {
-    bitsize: u8,
-    selsize: u8
+    bitsize: BitSize,
+    selsize: SelSize
 }
 impl Demux {
     /// Creates a new instance of the Demux with specified bitsize and selector size.
     pub fn new(bitsize: u8, selsize: u8) -> Self {
         Self {
-            bitsize: bitsize.clamp(BitArray::MIN_BITSIZE, BitArray::MAX_BITSIZE),
-            selsize: selsize.clamp(MIN_SELSIZE, MAX_SELSIZE)
+            bitsize: BitSize::new_clamped(bitsize),
+            selsize: SelSize::new_clamped(selsize)
         }
     }
 
-    pub(crate) fn n_outputs_from(selsize: u8) -> usize {
-        1 << selsize
+    pub(crate) fn n_outputs_from(selsize: SelSize) -> usize {
+        1 << selsize.get()
     }
     /// The number of outputs.
     pub fn n_outputs(self) -> usize {
@@ -80,22 +83,22 @@ impl Component for Demux {
     fn ports(&self, _: &CircuitGraphMap) -> Vec<PortProperties> {
             port_list(&[
             // selector
-            (PortProperties { ty: PortType::Input, bitsize: self.selsize }, 1),
+            (PortProperties { ty: PortType::Input, bitsize: self.selsize.get() }, 1),
             // input
-            (PortProperties { ty: PortType::Input, bitsize: self.bitsize }, 1),
+            (PortProperties { ty: PortType::Input, bitsize: self.bitsize.get() }, 1),
             // outputs
-            (PortProperties { ty: PortType::Output, bitsize: self.bitsize }, self.n_outputs()),
+            (PortProperties { ty: PortType::Output, bitsize: self.bitsize.get() }, self.n_outputs()),
         ])
     }
     fn run_inner(&self, ctx: RunContext<'_>) -> Vec<PortUpdate> {
         let m_sel = u64::try_from(ctx.new_ports[0]);
         let result = match m_sel {
             Ok(sel) => {
-                let mut result = vec![bitarr![0; self.bitsize]; self.n_outputs()];
+                let mut result = vec![bitarr![0; self.bitsize.get()]; self.n_outputs()];
                 result[sel as usize] = ctx.new_ports[1];
                 result
             },
-            Err(e) => vec![BitArray::repeat(e.bit_state(), self.bitsize); self.n_outputs()],
+            Err(e) => vec![BitArray::repeat(e.bit_state(), self.bitsize.get()); self.n_outputs()],
         };
 
         result.into_iter()
@@ -108,18 +111,18 @@ impl Component for Demux {
 /// A decoder component.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Decoder {
-    selsize: u8
+    selsize: SelSize
 }
 impl Decoder {
     /// Creates a new instance of the Decoder with specified selector size.
     pub fn new(selsize: u8) -> Self {
         Self {
-            selsize: selsize.clamp(MIN_SELSIZE, MAX_SELSIZE)
+            selsize: SelSize::new_clamped(selsize)
         }
     }
 
-    pub(crate) fn n_outputs_from(selsize: u8) -> usize {
-        1 << selsize
+    pub(crate) fn n_outputs_from(selsize: SelSize) -> usize {
+        1 << selsize.get()
     }
     /// The number of outputs
     pub fn n_outputs(self) -> usize {
@@ -130,7 +133,7 @@ impl Component for Decoder {
     fn ports(&self, _: &CircuitGraphMap) -> Vec<PortProperties> {
         port_list(&[
             // selector
-            (PortProperties { ty: PortType::Input, bitsize: self.selsize }, 1),
+            (PortProperties { ty: PortType::Input, bitsize: self.selsize.get() }, 1),
             // outputs
             (PortProperties { ty: PortType::Output, bitsize: 1 }, self.n_outputs()),
         ])

--- a/packages/backend/src/engine/func/wiring.rs
+++ b/packages/backend/src/engine/func/wiring.rs
@@ -1,30 +1,30 @@
 use crate::bitarray::BitArray;
 use crate::engine::CircuitGraphMap;
-use crate::engine::func::{Component, PortProperties, PortType, PortUpdate, RunContext, Sensitivity, port_list};
+use crate::engine::func::{BitSize, Component, PortProperties, PortType, PortUpdate, RunContext, Sensitivity, port_list};
 
 /// An input.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Input {
-    bitsize: u8
+    bitsize: BitSize
 }
 impl Input {
     /// Creates a new instance of the tri-state buffer with specified bitsize.
     pub fn new(bitsize: u8) -> Self {
         Self {
-            bitsize: bitsize.clamp(BitArray::MIN_BITSIZE, BitArray::MAX_BITSIZE)
+            bitsize: BitSize::new_clamped(bitsize)
         }
     }
 
     /// Gets the bitsize of this component.
     pub fn get_bitsize(&self) -> u8 {
-        self.bitsize
+        self.bitsize.get()
     }
 }
 impl Component for Input {
     fn ports(&self, _: &CircuitGraphMap) -> Vec<PortProperties> {
         port_list(&[
             // output
-            (PortProperties { ty: PortType::Output, bitsize: self.bitsize }, 1),
+            (PortProperties { ty: PortType::Output, bitsize: self.bitsize.get() }, 1),
         ])
     }
 
@@ -36,26 +36,26 @@ impl Component for Input {
 /// An output.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Output {
-    bitsize: u8
+    bitsize: BitSize
 }
 impl Output {
     /// Creates a new instance of the tri-state buffer with specified bitsize.
     pub fn new(bitsize: u8) -> Self {
         Self {
-            bitsize: bitsize.clamp(BitArray::MIN_BITSIZE, BitArray::MAX_BITSIZE)
+            bitsize: BitSize::new_clamped(bitsize)
         }
     }
 
     /// Gets the bitsize of this component.
     pub fn get_bitsize(&self) -> u8 {
-        self.bitsize
+        self.bitsize.get()
     }
 }
 impl Component for Output {
     fn ports(&self, _: &CircuitGraphMap) -> Vec<PortProperties> {
         port_list(&[
             // output
-            (PortProperties { ty: PortType::Input, bitsize: self.bitsize }, 1),
+            (PortProperties { ty: PortType::Input, bitsize: self.bitsize.get() }, 1),
         ])
     }
 
@@ -99,26 +99,26 @@ impl Component for Constant {
 /// A splitter component.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Splitter {
-    bitsize: u8
+    bitsize: BitSize
 }
 impl Splitter {
     /// Creates a new instance of the Splitter with specified bitsize.
     pub fn new(bitsize: u8) -> Self {
         Self {
-            bitsize: bitsize.clamp(BitArray::MIN_BITSIZE, BitArray::MAX_BITSIZE)
+            bitsize: BitSize::new_clamped(bitsize)
         }
     }
 
     /// Gets the bitsize of this component.
     pub fn get_bitsize(&self) -> u8 {
-        self.bitsize
+        self.bitsize.get()
     }
 }
 impl Component for Splitter {
     fn ports(&self, _: &CircuitGraphMap) -> Vec<PortProperties> {
         port_list(&[
             // joined
-            (PortProperties { ty: PortType::Inout, bitsize: self.bitsize }, 1),
+            (PortProperties { ty: PortType::Inout, bitsize: self.bitsize.get() }, 1),
             // split
             (PortProperties { ty: PortType::Inout, bitsize: 1 }, usize::from(self.bitsize)),
         ])

--- a/packages/backend/src/middle_end/func/gates.rs
+++ b/packages/backend/src/middle_end/func/gates.rs
@@ -1,4 +1,4 @@
-use crate::engine::func;
+use crate::engine::func::{self, BitSize, GateInputs};
 use crate::middle_end::func::{AbsoluteComponentBounds, Orientation, PhysicalComponent, PhysicalInitContext, RelativeComponentBounds};
 
 pub use func::GateKind;
@@ -8,13 +8,13 @@ pub use func::GateKind;
 #[cfg_attr(feature="serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Gate {
     kind: GateKind,
-    bitsize: u8,
-    n_inputs: u8,
+    bitsize: BitSize,
+    n_inputs: GateInputs,
     orientation: Orientation
 }
 impl PhysicalComponent for Gate {
     fn init_engine(&self) -> Option<func::ComponentFn> {
-        Some(func::Gate::new(self.kind, self.bitsize, self.n_inputs).into())
+        Some(func::Gate::new(self.kind, self.bitsize.get(), self.n_inputs.get()).into())
     }
 
     fn component_name(&self) -> &'static str {
@@ -24,7 +24,7 @@ impl PhysicalComponent for Gate {
     fn init_bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
         // The origin is at the output port, which is at (4,2) in absolute coordinates.
         let bounds = [(-4, -2), (0, 2)];
-        let inputs = i32::from(self.n_inputs);
+        let inputs = i32::from(self.n_inputs.get());
         
         let mut ports = vec![];
         // Input ports
@@ -42,13 +42,13 @@ impl PhysicalComponent for Gate {
 #[cfg_attr(feature="serde", derive(serde::Serialize, serde::Deserialize))]
 /// A NOT gate component.
 pub struct Not {
-    bitsize: u8,
+    bitsize: BitSize,
     orientation: Orientation
 }
 
 impl PhysicalComponent for Not {
     fn init_engine(&self) -> Option<func::ComponentFn> {
-        Some(func::Not::new(self.bitsize).into())
+        Some(func::Not::new(self.bitsize.get()).into())
     }
 
     fn component_name(&self) -> &'static str {
@@ -67,13 +67,13 @@ impl PhysicalComponent for Not {
 #[cfg_attr(feature="serde", derive(serde::Serialize, serde::Deserialize))]
 /// A tri-state buffer.
 pub struct TriState {
-    bitsize: u8,
+    bitsize: BitSize,
     orientation: Orientation
 }
 
 impl PhysicalComponent for TriState {
     fn init_engine(&self) -> Option<func::ComponentFn> {
-        Some(func::TriState::new(self.bitsize).into())
+        Some(func::TriState::new(self.bitsize.get()).into())
     }
 
     fn component_name(&self) -> &'static str {

--- a/packages/backend/src/middle_end/func/muxes.rs
+++ b/packages/backend/src/middle_end/func/muxes.rs
@@ -1,4 +1,4 @@
-use crate::engine::func::{self, ComponentFn};
+use crate::engine::func::{self, BitSize, ComponentFn, SelSize};
 use crate::middle_end::func::{AbsoluteComponentBounds, Handedness, Orientation, PhysicalComponent, PhysicalInitContext, RelativeComponentBounds};
 
 const PLEXER_WIDTH: u32 = 3;
@@ -7,14 +7,14 @@ const PLEXER_WIDTH: u32 = 3;
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 #[cfg_attr(feature="serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Mux {
-    bitsize: u8,
-    selsize: u8,
+    bitsize: BitSize,
+    selsize: SelSize,
     orientation: Orientation,
     handedness: Handedness
 }
 impl PhysicalComponent for Mux {
     fn init_engine(&self) -> Option<ComponentFn> {
-        Some(func::Mux::new(self.bitsize, self.selsize).into())
+        Some(func::Mux::new(self.bitsize.get(), self.selsize.get()).into())
     }
 
     fn component_name(&self) ->  &'static str {
@@ -43,14 +43,14 @@ impl PhysicalComponent for Mux {
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 #[cfg_attr(feature="serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Demux {
-    bitsize: u8,
-    selsize: u8,
+    bitsize: BitSize,
+    selsize: SelSize,
     orientation: Orientation,
     handedness: Handedness
 }
 impl PhysicalComponent for Demux {
     fn init_engine(&self) -> Option<ComponentFn> {
-        Some(func::Demux::new(self.bitsize, self.selsize).into())
+        Some(func::Demux::new(self.bitsize.get(), self.selsize.get()).into())
     }
 
     fn component_name(&self) ->  &'static str {
@@ -77,13 +77,13 @@ impl PhysicalComponent for Demux {
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 #[cfg_attr(feature="serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Decoder {
-    selsize: u8,
+    selsize: SelSize,
     orientation: Orientation,
     handedness: Handedness
 }
 impl PhysicalComponent for Decoder {
     fn init_engine(&self) -> Option<ComponentFn> {
-        Some(func::Decoder::new(self.selsize).into())
+        Some(func::Decoder::new(self.selsize.get()).into())
     }
 
     fn component_name(&self) ->  &'static str {

--- a/packages/backend/src/middle_end/func/wiring.rs
+++ b/packages/backend/src/middle_end/func/wiring.rs
@@ -1,5 +1,5 @@
 use crate::bitarray::BitArray;
-use crate::engine::func;
+use crate::engine::func::{self, BitSize};
 use crate::bitarr;
 use crate::middle_end::func::{Handedness, Orientation, PhysicalComponent, PhysicalInitContext, RelativeComponentBounds};
 
@@ -7,15 +7,15 @@ use crate::middle_end::func::{Handedness, Orientation, PhysicalComponent, Physic
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 #[cfg_attr(feature="serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Pin {
-    bitsize: u8,
+    bitsize: BitSize,
     is_input: bool,
     orientation: Orientation
 }
 impl PhysicalComponent for Pin {
     fn init_engine(&self) -> Option<func::ComponentFn> {
         Some(match self.is_input {
-            true  => func::Input::new(self.bitsize).into(),
-            false => func::Output::new(self.bitsize).into()
+            true  => func::Input::new(self.bitsize.get()).into(),
+            false => func::Output::new(self.bitsize.get()).into()
         })
     }
 
@@ -27,7 +27,7 @@ impl PhysicalComponent for Pin {
     }
 
     fn init_bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
-        RelativeComponentBounds::single_port_from_bitsize(self.bitsize)
+        RelativeComponentBounds::single_port_from_bitsize(self.bitsize.get())
             .orient(self.orientation, Default::default())
     }
 }
@@ -94,13 +94,13 @@ impl PhysicalComponent for Ground {
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 #[cfg_attr(feature="serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Splitter {
-    bitsize: u8,
+    bitsize: BitSize,
     orientation: Orientation,
     handedness: Handedness
 }
 impl PhysicalComponent for Splitter {
     fn init_engine(&self) -> Option<func::ComponentFn> {
-        Some(func::Splitter::new(self.bitsize).into())
+        Some(func::Splitter::new(self.bitsize.get()).into())
     }
 
     fn component_name(&self) -> &'static str {
@@ -108,7 +108,7 @@ impl PhysicalComponent for Splitter {
     }
 
     fn init_bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
-        let bitsize = i32::from(self.bitsize);
+        let bitsize = i32::from(self.bitsize.get());
         let mut ports = vec![(0, 0)];
         ports.extend((1..=bitsize).map(|i| (2 * i, 2)));
 


### PR DESCRIPTION
Imposes ranged integers for various integer types (bitsize, selsize, etc.). These restrict the range of possible integers that a field can accept.

The idea behind this is that deser. can validate these types and we get input validation for free!