### PR TITLE
ME serialization & deserialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,7 @@ dependencies = [
  "serde_json",
  "slotmap",
  "strum",
+ "thiserror",
 ]
 
 [[package]]
@@ -452,6 +453,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,9 +220,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "libloading"
@@ -305,9 +305,9 @@ checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "petgraph"
@@ -323,9 +323,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "proc-macro2"
@@ -338,9 +338,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -417,9 +417,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -428,15 +428,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "version_check"
@@ -452,6 +452,6 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "zmij"
-version = "1.0.19"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,6 +23,7 @@ dependencies = [
  "serde",
  "serde_json",
  "slotmap",
+ "strum",
 ]
 
 [[package]]
@@ -207,6 +208,12 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "indexmap"
@@ -413,6 +420,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
 dependencies = [
  "version_check",
+]
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/packages/backend/Cargo.toml
+++ b/packages/backend/Cargo.toml
@@ -3,11 +3,15 @@ name = "circuitsim-engine"
 version = "0.1.0"
 edition = "2024"
 
+[features]
+default=["serde"]
+serde=["dep:serde", "dep:serde_json"]
+
 [dependencies]
 enum_dispatch = "0.3.13"
 petgraph = "0.8.3"
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.145"
+serde = { version = "1.0.228", features = ["derive"], optional = true }
+serde_json = { version = "1.0.145", optional = true }
 slotmap = "1.0.7"
 strum = { version = "0.28.0", features = ["derive"] }
 thiserror = "2.0.18"

--- a/packages/backend/Cargo.toml
+++ b/packages/backend/Cargo.toml
@@ -9,3 +9,4 @@ petgraph = "0.8.3"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 slotmap = "1.0.7"
+strum = { version = "0.28.0", features = ["derive"] }

--- a/packages/backend/Cargo.toml
+++ b/packages/backend/Cargo.toml
@@ -10,3 +10,4 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 slotmap = "1.0.7"
 strum = { version = "0.28.0", features = ["derive"] }
+thiserror = "2.0.18"

--- a/packages/backend/src/bitarray.rs
+++ b/packages/backend/src/bitarray.rs
@@ -736,6 +736,61 @@ impl std::ops::Not for BitArray {
     }
 }
 
+#[cfg(feature="serde")]
+mod serde {
+    use serde::de::{Unexpected, Visitor};
+    use serde::{Deserialize, Serialize};
+
+    use crate::bitarray::{BitArray, BitState};
+
+    impl Serialize for BitArray {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where S: serde::Serializer
+        {
+            serializer.collect_str(self)
+        }
+    }
+    impl<'de> Deserialize<'de> for BitArray {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where D: serde::Deserializer<'de>
+        {
+            struct BaVisitor;
+            impl<'de> Visitor<'de> for BaVisitor {
+                type Value = BitArray;
+            
+                fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                    write!(formatter, " a string")
+                }
+
+                fn visit_bool<E>(self, v: bool) -> Result<Self::Value, E>
+                    where E: serde::de::Error
+                {
+                    Ok(BitArray::from(BitState::from(v)))
+                }
+                fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+                    where E: serde::de::Error
+                {
+                    Ok(BitArray::from(v))
+                }
+                fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+                    where E: serde::de::Error
+                {
+                    v.parse()
+                        .map_err(|_| E::invalid_value(Unexpected::Str(v), &"valid bitarray"))
+                }
+
+                fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+                    where E: serde::de::Error
+                {
+                    self.visit_str(std::str::from_utf8(v).map_err(|e| E::custom(e))?)
+                }
+            }
+            
+            deserializer.deserialize_any(BaVisitor)
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/packages/backend/src/bitarray.rs
+++ b/packages/backend/src/bitarray.rs
@@ -1,5 +1,10 @@
 //! Bit manipulation used for wires and bit values.
 
+mod ranged;
+pub(crate) use ranged::RangedByte;
+
+type BitSize = RangedByte<0, { u64::BITS as u8 }>;
+
 /// A `u64` bit mask of `len` 1s,
 /// useful for masking against values which
 /// should not affect [`BitArray`] comparisons.
@@ -248,7 +253,7 @@ pub struct BitArray {
     // Note that while this is implemented internally as LSB = index 0.
     data: u64,
     spec: u64,
-    len: u8
+    len: BitSize
 }
 
 /// Creates a [`BitState`].
@@ -309,7 +314,7 @@ impl BitArray {
     /// Any bits after index `(len - 1)` in `data` are ignored.
     /// The least-significant bit of `data` acts as index 0.
     pub fn from_bits(data: u64, len: u8) -> Self {
-        Self { data, spec: 0, len: len.clamp(BitArray::MIN_BITSIZE, BitArray::MAX_BITSIZE) }
+        Self { data, spec: 0, len: RangedByte::new_clamped(len) }
     }
 
     /// Creates a new array where the bit state is repeated `len` times.
@@ -318,17 +323,13 @@ impl BitArray {
         Self {
             data: stretch(data),
             spec: stretch(spec),
-            len: len.clamp(BitArray::MIN_BITSIZE, BitArray::MAX_BITSIZE)
+            len: RangedByte::new_clamped(len)
         }
     }
 
     /// The length of the array.
     pub const fn len(self) -> u8 {
-        match self.len {
-            ..BitArray::MIN_BITSIZE => BitArray::MIN_BITSIZE,
-            len @ BitArray::MIN_BITSIZE..BitArray::MAX_BITSIZE => len,
-            _ => BitArray::MAX_BITSIZE,
-        }
+        self.len.get()
     }
     /// Whether the array has no elements.
     pub fn is_empty(self) -> bool {
@@ -418,7 +419,7 @@ impl BitArray {
     /// If the new bitsize is larger than the current bitsize,
     /// it is extended with the specified array.
     pub fn resize(self, new_len: u8, fill: BitState) -> Self {
-        let new_len = new_len.clamp(BitArray::MIN_BITSIZE, BitArray::MAX_BITSIZE);
+        let new_len = BitSize::new_clamped(new_len);
         if new_len <= self.len() {
             // Truncation
             Self { data: self.data, spec: self.spec, len: new_len }
@@ -438,10 +439,44 @@ impl BitArray {
 
     /// Shifts the bitarray by the specified `shift`, using the applied `shift_type`.
     pub fn shift(self, shift: u32, shift_type: ShiftType) -> Self {
-        let data = shift_type.apply(self.data, self.len, shift);
-        let spec = shift_type.apply(self.spec, self.len, shift);
+        let data = shift_type.apply(self.data, self.len(), shift);
+        let spec = shift_type.apply(self.spec, self.len(), shift);
 
         Self { data, spec, len: self.len }
+    }
+
+    /// Pops the bitstate from the 0th index, removing it from the bitarray.
+    /// 
+    /// Returns None if BitArray is empty.
+    fn pop_front(&mut self) -> Option<BitState> {
+            let nl = self.len.decremented()?;
+            let raw = self.get_raw(0);
+            self.data >>= 1;
+            self.spec >>= 1;
+            self.len = nl;
+            Some(raw)
+    }
+
+    /// Pops the bitstate from the (len-1)th index, removing it from the bitarray.
+    /// 
+    /// Returns None if BitArray is empty.
+    fn pop_back(&mut self) -> Option<BitState> {
+        let nl = self.len.decremented()?;
+        self.len = nl;
+        Some(self.get_raw(nl.get()))
+    }
+
+    /// Pushes the bitstate to the end of the array (i.e., to the (len)th index).
+    /// 
+    /// Returns whether the push was successful.
+    fn push_back(&mut self, st: BitState) -> bool {
+        if let Some(nl) = self.len.incremented() {
+            self.set_raw(self.len(), st);
+            self.len = nl;
+            true
+        } else {
+            false
+        }
     }
 }
 impl FromIterator<BitState> for BitArray {
@@ -468,10 +503,9 @@ impl FromIterator<BitState> for BitArray {
     /// ```
     fn from_iter<I: IntoIterator<Item = BitState>>(iter: I) -> Self {
         iter.into_iter()
-            .zip(0..64)
-            .fold(BitArray::new(), |mut arr, (st, i)| {
-                arr.set_raw(i, st);
-                arr.len += 1;
+            .take(64)
+            .fold(BitArray::new(), |mut arr, st| {
+                assert!(arr.push_back(st));
                 arr
             })
     }
@@ -515,13 +549,7 @@ impl Iterator for BitArrayIntoIter {
     type Item = BitState;
 
     fn next(&mut self) -> Option<Self::Item> {
-        (!self.0.is_empty()).then(|| {
-            let raw = self.0.get_raw(0);
-            self.0.data >>= 1;
-            self.0.spec >>= 1;
-            self.0.len -= 1;
-            raw
-        })
+        self.0.pop_front()
     }
     fn size_hint(&self) -> (usize, Option<usize>) {
         let len = self.len();
@@ -530,16 +558,12 @@ impl Iterator for BitArrayIntoIter {
 }
 impl DoubleEndedIterator for BitArrayIntoIter {
     fn next_back(&mut self) -> Option<Self::Item> {
-        (!self.0.is_empty()).then(|| {
-            let raw = self.0.get_raw(self.0.len() - 1);
-            self.0.len -= 1;
-            raw
-        })
+        self.0.pop_back()
     }
 }
 impl ExactSizeIterator for BitArrayIntoIter {
     fn len(&self) -> usize {
-        usize::from(self.0.len())
+        usize::from(self.0.len)
     }
 }
 impl IntoIterator for BitArray {
@@ -616,14 +640,13 @@ impl BitArray {
         // 01 | 11 | 11 | 01 | 11
         // 10 | 00 | 01 | 10 | 11
         // 11 | 11 | 11 | 11 | 11
-        let len = self.len();
         let lz = self.is(BitState::Imped);
         let rz = rhs.is(BitState::Imped);
 
         let data = (!lz & !rz) | (lz & !rz & rhs.data) | (rz & self.data);
         let spec = (!lz & !rz) | (lz & !rz & rhs.spec) | (rz & self.spec);
         
-        Self { data, spec, len }
+        Self { data, spec, len: self.len }
     }
 
     pub(crate) fn short_circuits(self, occupied: u64) -> Option<u64> {
@@ -681,7 +704,7 @@ impl std::ops::BitAnd for BitArray {
 
         let data = !any_false;
         let spec = !any_false & !all_true;
-        let len = self.len();
+        let len = self.len;
         Self { spec, data, len }
     }
 }

--- a/packages/backend/src/bitarray/ranged.rs
+++ b/packages/backend/src/bitarray/ranged.rs
@@ -1,0 +1,104 @@
+/// A u8 which is restricted to the `MIN..=MAX` range.
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
+#[cfg_attr(feature="serde", derive(serde::Serialize), serde(transparent))]
+pub struct RangedByte<const MIN: u8, const MAX: u8>(u8);
+
+impl<const MIN: u8, const MAX: u8> RangedByte<MIN, MAX> {
+    /// Creates a new [`RangedByte`],
+    /// or returns None if value is out of bounds.
+    pub const fn new(n: u8) -> Option<Self> {
+        const { assert!(MIN <= MAX); }
+        if MIN <= n && n <= MAX {
+            Some(Self(n))
+        } else {
+            None
+        }
+    }
+    /// Creates a new [`RangedByte`],
+    /// clamping to the bounds if out of bounds.
+    pub fn new_clamped(n: u8) -> Self {
+        const { assert!(MIN <= MAX); }
+        Self(n.clamp(MIN, MAX))
+    }
+    /// Gets the value.
+    pub const fn get(self) -> u8 {
+        self.0
+    }
+
+    /// Increments value if result would stay in bound.
+    pub const fn incremented(self) -> Option<Self> {
+        match self.0 < MAX {
+            true => Some(Self(self.0 + 1)),
+            false => None
+        }
+    }
+    /// Decrements value if result would stay in bound.
+    pub const fn decremented(self) -> Option<Self> {
+        match self.0 > MIN {
+            true => Some(Self(self.0 - 1)),
+            false => None
+        }
+    }
+}
+
+impl<const MIN: u8, const MAX: u8> std::fmt::Debug for RangedByte<MIN, MAX> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+impl<const MIN: u8, const MAX: u8> std::fmt::Display for RangedByte<MIN, MAX> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl<const MIN: u8, const MAX: u8> PartialEq<u8> for RangedByte<MIN, MAX> {
+    fn eq(&self, other: &u8) -> bool {
+        self.0 == *other
+    }
+}
+impl<const MIN: u8, const MAX: u8> PartialOrd<u8> for RangedByte<MIN, MAX> {
+    fn partial_cmp(&self, other: &u8) -> Option<std::cmp::Ordering> {
+        Some(self.0.cmp(other))
+    }
+}
+impl<const MIN: u8, const MAX: u8> PartialEq<RangedByte<MIN, MAX>> for u8 {
+    fn eq(&self, other: &RangedByte<MIN, MAX>) -> bool {
+        *self == other.0
+    }
+}
+impl<const MIN: u8, const MAX: u8> PartialOrd<RangedByte<MIN, MAX>> for u8 {
+    fn partial_cmp(&self, other: &RangedByte<MIN, MAX>) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(&other.0))
+    }
+}
+impl<const MAX: u8> Default for RangedByte<0, MAX> {
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
+
+impl<const MIN: u8, const MAX: u8> From<RangedByte<MIN, MAX>> for u8 {
+    fn from(value: RangedByte<MIN, MAX>) -> Self {
+        value.get()
+    }
+}
+impl<const MIN: u8, const MAX: u8> From<RangedByte<MIN, MAX>> for usize {
+    fn from(value: RangedByte<MIN, MAX>) -> Self {
+        usize::from(value.get())
+    }
+}
+
+#[cfg(feature="serde")]
+impl<'de, const MIN: u8, const MAX: u8> serde::Deserialize<'de> for RangedByte<MIN, MAX> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where D: serde::Deserializer<'de>
+    {
+        let n = u8::deserialize(deserializer)?;
+        Self::new(n)
+            .ok_or_else(|| serde::de::Error::invalid_value(
+                serde::de::Unexpected::Unsigned(n.into()),
+                &&*format!("integer in {MIN}..={MAX}")
+            ))
+    }
+}

--- a/packages/backend/src/engine/func/arithmetic.rs
+++ b/packages/backend/src/engine/func/arithmetic.rs
@@ -3,7 +3,7 @@ use std::cmp::Ordering;
 use crate::bitarr;
 use crate::bitarray::{NotTwoValuedErr, ShiftType};
 use crate::engine::CircuitGraphMap;
-use crate::engine::func::{Component, PortProperties, PortType, PortUpdate, RunContext, port_list};
+use crate::engine::func::{BitSize, Component, PortProperties, PortType, PortUpdate, RunContext, port_list};
 use crate::{bitarray::BitArray, bitarray::BitState};
 
 /// Parses a set of inputs, returning the results of each port.
@@ -48,13 +48,13 @@ fn sign_extend_128(n: u128, bitsize: u8) -> i128 {
 /// An adder component.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Adder {
-    bitsize: u8
+    bitsize: BitSize
 }
 impl Adder {
     /// Creates a new instance of the Adder with specified bitsize.
     pub fn new(bitsize: u8) -> Self {
         Self {
-            bitsize: bitsize.clamp(BitArray::MIN_BITSIZE, BitArray::MAX_BITSIZE),
+            bitsize: BitSize::new_clamped(bitsize),
         }
     }
 }
@@ -62,13 +62,13 @@ impl Component for Adder {
     fn ports(&self, _: &CircuitGraphMap) -> Vec<PortProperties> {
         port_list(&[
             // inputs A and B for Adder
-            (PortProperties { ty: PortType::Input, bitsize: self.bitsize }, 2),
+            (PortProperties { ty: PortType::Input, bitsize: self.bitsize.get() }, 2),
             // Carry In Bit
             (PortProperties { ty: PortType::Input, bitsize: 1}, 1),
             // Carry Out Bit
             (PortProperties { ty: PortType::Output, bitsize: 1}, 1),
             // output
-            (PortProperties { ty: PortType::Output, bitsize: self.bitsize }, 1),
+            (PortProperties { ty: PortType::Output, bitsize: self.bitsize.get() }, 1),
         ])
     }
 
@@ -85,26 +85,26 @@ impl Component for Adder {
             Ok([Some(a), Some(b), cin]) => (a, b, cin),
             Ok(_) => return vec![
                 PortUpdate { index: 3, value: bitarr![Z] },
-                PortUpdate { index: 4, value: bitarr![Z; self.bitsize] },
+                PortUpdate { index: 4, value: bitarr![Z; self.bitsize.get()] },
             ],
             Err(_) => return vec![
                 PortUpdate { index: 3, value: bitarr![X] },
-                PortUpdate { index: 4, value: bitarr![X; self.bitsize] },
+                PortUpdate { index: 4, value: bitarr![X; self.bitsize.get()] },
             ]
         };
         let cin = cin.unwrap_or(0);
 
         let (sum, cout) = a.carrying_add(b, cin & 1 != 0);
-        match self.bitsize {
+        match self.bitsize.get() {
             64.. => vec![
                 PortUpdate { index: 3, value: BitArray::from(cout) },
                 PortUpdate { index: 4, value: BitArray::from(sum) }
             ],
             _ => {
-                let cout = sum & (1 << self.bitsize) != 0;
+                let cout = sum & (1 << self.bitsize.get()) != 0;
                 vec![
                     PortUpdate { index: 3, value: BitArray::from(cout) },
-                    PortUpdate { index: 4, value: BitArray::from_bits(sum, self.bitsize) }
+                    PortUpdate { index: 4, value: BitArray::from_bits(sum, self.bitsize.get()) }
                 ]
             }
         }
@@ -114,13 +114,13 @@ impl Component for Adder {
 /// A subtractor component.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Subtractor {
-    bitsize: u8
+    bitsize: BitSize
 }
 impl Subtractor {
     /// Creates a new instance of the Subtractor with specified bitsize.
     pub fn new(bitsize: u8) -> Self {
         Self {
-            bitsize: bitsize.clamp(BitArray::MIN_BITSIZE, BitArray::MAX_BITSIZE),
+            bitsize: BitSize::new_clamped(bitsize),
         }
     }
 }
@@ -128,13 +128,13 @@ impl Component for Subtractor {
     fn ports(&self, _: &CircuitGraphMap) -> Vec<PortProperties> {
         port_list(&[
             // inputs A and B for Subtractor
-            (PortProperties { ty: PortType::Input, bitsize: self.bitsize }, 2),
+            (PortProperties { ty: PortType::Input, bitsize: self.bitsize.get() }, 2),
             // Borrow In Bit
             (PortProperties { ty: PortType::Input, bitsize: 1}, 1),
             // Borrow Out Bit
             (PortProperties { ty: PortType::Output, bitsize: 1}, 1),
             // output
-            (PortProperties { ty: PortType::Output, bitsize: self.bitsize }, 1),
+            (PortProperties { ty: PortType::Output, bitsize: self.bitsize.get() }, 1),
         ])
     }
 
@@ -151,26 +151,26 @@ impl Component for Subtractor {
             Ok([Some(a), Some(b), bin]) => (a, b, bin),
             Ok(_) => return vec![
                 PortUpdate { index: 3, value: bitarr![Z] },
-                PortUpdate { index: 4, value: bitarr![Z; self.bitsize] },
+                PortUpdate { index: 4, value: bitarr![Z; self.bitsize.get()] },
             ],
             Err(_) => return vec![
                 PortUpdate { index: 3, value: bitarr![X] },
-                PortUpdate { index: 4, value: bitarr![X; self.bitsize] },
+                PortUpdate { index: 4, value: bitarr![X; self.bitsize.get()] },
             ]
         };
         let bin = bin.unwrap_or(0);
 
         let (diff, bout) = a.borrowing_sub(b, bin & 1 != 0);
-        match self.bitsize {
+        match self.bitsize.get() {
             64.. => vec![
                 PortUpdate { index: 3, value: BitArray::from(bout) },
                 PortUpdate { index: 4, value: BitArray::from(diff) }
             ],
             _ => {
-                let bout = diff & (1 << self.bitsize) != 0;
+                let bout = diff & (1 << self.bitsize.get()) != 0;
                 vec![
                     PortUpdate { index: 3, value: BitArray::from(bout) },
-                    PortUpdate { index: 4, value: BitArray::from_bits(diff, self.bitsize) }
+                    PortUpdate { index: 4, value: BitArray::from_bits(diff, self.bitsize.get()) }
                 ]
             }
         }
@@ -181,14 +181,14 @@ impl Component for Subtractor {
 /// A multiplier component.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Multiplier {
-    bitsize: u8,
+    bitsize: BitSize,
     signedness: SignType
 }
 impl Multiplier {
     /// Creates a new instance of the Multiplier with specified bitsize.
     pub fn new(bitsize: u8, signedness: SignType) -> Self {
         Self {
-            bitsize: bitsize.clamp(BitArray::MIN_BITSIZE, BitArray::MAX_BITSIZE),
+            bitsize: BitSize::new_clamped(bitsize),
             signedness
         }
     }
@@ -204,9 +204,9 @@ impl Component for Multiplier {
                 [4] = Carry Out / Upper Bits
              */
             // Inputs
-            (PortProperties { ty: PortType::Input, bitsize: self.bitsize }, 3),
+            (PortProperties { ty: PortType::Input, bitsize: self.bitsize.get() }, 3),
             // Outputs
-            (PortProperties { ty: PortType::Output, bitsize: self.bitsize }, 2),
+            (PortProperties { ty: PortType::Output, bitsize: self.bitsize.get() }, 2),
         ])
     }
 
@@ -222,17 +222,17 @@ impl Component for Multiplier {
         let (a, b, cin) = match parse_args(ctx.new_ports) {
             Ok([Some(a), Some(b), cin]) => (a, b, cin),
             Ok(_) => return vec![
-                PortUpdate { index: 3, value: bitarr![Z; self.bitsize] },
-                PortUpdate { index: 4, value: bitarr![Z; self.bitsize] },
+                PortUpdate { index: 3, value: bitarr![Z; self.bitsize.get()] },
+                PortUpdate { index: 4, value: bitarr![Z; self.bitsize.get()] },
             ],
             Err(_) => return vec![
-                PortUpdate { index: 3, value: bitarr![X; self.bitsize] },
-                PortUpdate { index: 4, value: bitarr![X; self.bitsize] },
+                PortUpdate { index: 3, value: bitarr![X; self.bitsize.get()] },
+                PortUpdate { index: 4, value: bitarr![X; self.bitsize.get()] },
             ]
         };
         let cin = cin.unwrap_or(0);
 
-        match (self.bitsize, self.signedness) {
+        match (self.bitsize.get(), self.signedness) {
             (64.., SignType::Unsigned) => {
                 let (prod, cout) = a.carrying_mul(b, cin);
                 vec![
@@ -243,26 +243,26 @@ impl Component for Multiplier {
             (..64, SignType::Unsigned) => {
                 let (prod_lo, prod_hi) = a.carrying_mul(b, cin);
                 let full_prod = (u128::from(prod_hi) << 64) | u128::from(prod_lo);
-                let mask = (1u128 << self.bitsize) - 1;
+                let mask = (1u128 << self.bitsize.get()) - 1;
 
                 let prod = (full_prod & mask) as u64;
-                let cout = ((full_prod >> self.bitsize) & mask) as u64;
+                let cout = ((full_prod >> self.bitsize.get()) & mask) as u64;
                 vec![
-                    PortUpdate { index: 3, value: BitArray::from_bits(prod, self.bitsize) },
-                    PortUpdate { index: 4, value: BitArray::from_bits(cout, self.bitsize) },
+                    PortUpdate { index: 3, value: BitArray::from_bits(prod, self.bitsize.get()) },
+                    PortUpdate { index: 4, value: BitArray::from_bits(cout, self.bitsize.get()) },
                 ]
             },
             (_, SignType::TwosComplement) => {
-                let full_prod = sign_extend_128(u128::from(a), self.bitsize)
-                    .wrapping_mul(sign_extend_128(u128::from(b), self.bitsize))
-                    .wrapping_add(sign_extend_128(u128::from(cin), self.bitsize));
-                let mask = (1i128 << self.bitsize) - 1;
+                let full_prod = sign_extend_128(u128::from(a), self.bitsize.get())
+                    .wrapping_mul(sign_extend_128(u128::from(b), self.bitsize.get()))
+                    .wrapping_add(sign_extend_128(u128::from(cin), self.bitsize.get()));
+                let mask = (1i128 << self.bitsize.get()) - 1;
 
                 let prod = (full_prod & mask) as u64;
-                let cout = ((full_prod >> self.bitsize) & mask) as u64;
+                let cout = ((full_prod >> self.bitsize.get()) & mask) as u64;
                 vec![
-                    PortUpdate { index: 3, value: BitArray::from_bits(prod, self.bitsize) },
-                    PortUpdate { index: 4, value: BitArray::from_bits(cout, self.bitsize) },
+                    PortUpdate { index: 3, value: BitArray::from_bits(prod, self.bitsize.get()) },
+                    PortUpdate { index: 4, value: BitArray::from_bits(cout, self.bitsize.get()) },
                 ]
             }
         }
@@ -272,14 +272,14 @@ impl Component for Multiplier {
 /// A Divider component.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Divider {
-    bitsize: u8,
+    bitsize: BitSize,
     signedness: SignType
 }
 impl Divider {
     /// Creates a new instance of the Divider with specified bitsize.
     pub fn new(bitsize: u8, signedness: SignType) -> Self {
         Self {
-            bitsize: bitsize.clamp(BitArray::MIN_BITSIZE, BitArray::MAX_BITSIZE),
+            bitsize: BitSize::new_clamped(bitsize),
             signedness
         }
     }
@@ -295,9 +295,9 @@ impl Component for Divider {
                 [4] = Remainder
              */
             // Inputs
-            (PortProperties { ty: PortType::Input, bitsize: self.bitsize }, 3),
+            (PortProperties { ty: PortType::Input, bitsize: self.bitsize.get() }, 3),
             // Outputs
-            (PortProperties { ty: PortType::Input, bitsize: self.bitsize }, 2),
+            (PortProperties { ty: PortType::Input, bitsize: self.bitsize.get() }, 2),
         ])
     }
 
@@ -312,49 +312,49 @@ impl Component for Divider {
         let (a_lo, b, a_hi) = match parse_args(ctx.new_ports) {
             Ok([Some(a), Some(b), cin]) => (a, b, cin),
             Ok(_) => return vec![
-                PortUpdate { index: 3, value: bitarr![Z; self.bitsize] },
-                PortUpdate { index: 4, value: bitarr![Z; self.bitsize] },
+                PortUpdate { index: 3, value: bitarr![Z; self.bitsize.get()] },
+                PortUpdate { index: 4, value: bitarr![Z; self.bitsize.get()] },
             ],
             Err(_) => return vec![
-                PortUpdate { index: 3, value: bitarr![X; self.bitsize] },
-                PortUpdate { index: 4, value: bitarr![X; self.bitsize] },
+                PortUpdate { index: 3, value: bitarr![X; self.bitsize.get()] },
+                PortUpdate { index: 4, value: bitarr![X; self.bitsize.get()] },
             ]
         };
         match (b, self.signedness) {
             // Div by zero, just let it be div by 1
             (0, _) => {
                 vec![
-                    PortUpdate { index: 3, value: BitArray::from_bits(a_lo, self.bitsize) },
-                    PortUpdate { index: 4, value: BitArray::from_bits(0, self.bitsize) },
+                    PortUpdate { index: 3, value: BitArray::from_bits(a_lo, self.bitsize.get()) },
+                    PortUpdate { index: 4, value: BitArray::from_bits(0, self.bitsize.get()) },
                 ]
             }
             (_, SignType::Unsigned) => {
                 let a_hi = a_hi.unwrap_or(0); // ZEXT
-                let a = (u128::from(a_hi) << self.bitsize) | u128::from(a_lo);
+                let a = (u128::from(a_hi) << self.bitsize.get()) | u128::from(a_lo);
                 let b = u128::from(b);
 
                 vec![
-                    PortUpdate { index: 3, value: BitArray::from_bits((a / b) as u64, self.bitsize) },
-                    PortUpdate { index: 4, value: BitArray::from_bits((a % b) as u64, self.bitsize) },
+                    PortUpdate { index: 3, value: BitArray::from_bits((a / b) as u64, self.bitsize.get()) },
+                    PortUpdate { index: 4, value: BitArray::from_bits((a % b) as u64, self.bitsize.get()) },
                 ]
             }
             (_, SignType::TwosComplement) => {
                 let sa = match a_hi {
                     // a_hi concat a_lo
                     Some(a_hi) => sign_extend_128({
-                       (u128::from(a_hi) << self.bitsize) | u128::from(a_lo)
-                    }, self.bitsize * 2),
+                       (u128::from(a_hi) << self.bitsize.get()) | u128::from(a_lo)
+                    }, self.bitsize.get() * 2),
 
                     // a_lo, sign extended
-                    None => sign_extend_128(u128::from(a_lo), self.bitsize),
+                    None => sign_extend_128(u128::from(a_lo), self.bitsize.get()),
                 };
-                let sb = sign_extend_128(u128::from(b), self.bitsize);
+                let sb = sign_extend_128(u128::from(b), self.bitsize.get());
 
                 let div = sa / sb;
                 let rem = sa % sb;
                 vec![
-                    PortUpdate { index: 3, value: BitArray::from_bits(div as u64, self.bitsize) },
-                    PortUpdate { index: 4, value: BitArray::from_bits(rem as u64, self.bitsize) },
+                    PortUpdate { index: 3, value: BitArray::from_bits(div as u64, self.bitsize.get()) },
+                    PortUpdate { index: 4, value: BitArray::from_bits(rem as u64, self.bitsize.get()) },
                 ]
             }
         }
@@ -364,13 +364,13 @@ impl Component for Divider {
 /// A negator component.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Negator {
-    bitsize: u8
+    bitsize: BitSize
 }
 impl Negator {
     /// Creates a new instance of the negator with specified bitsize.
     pub fn new(bitsize: u8) -> Self {
         Self {
-            bitsize: bitsize.clamp(BitArray::MIN_BITSIZE, BitArray::MAX_BITSIZE),
+            bitsize: BitSize::new_clamped(bitsize),
         }
     }
 }
@@ -378,9 +378,9 @@ impl Component for Negator {
     fn ports(&self, _: &CircuitGraphMap) -> Vec<PortProperties> {
         port_list(&[
             // Input
-            (PortProperties { ty: PortType::Input, bitsize: self.bitsize }, 1),
+            (PortProperties { ty: PortType::Input, bitsize: self.bitsize.get() }, 1),
             // Output
-            (PortProperties { ty: PortType::Output, bitsize: self.bitsize }, 1),
+            (PortProperties { ty: PortType::Output, bitsize: self.bitsize.get() }, 1),
         ])
     }
 
@@ -389,11 +389,11 @@ impl Component for Negator {
             Ok(val) => val,
             Err(e) => return vec![PortUpdate {
                 index: 1,
-                value: BitArray::repeat(e.bit_state(), self.bitsize)
+                value: BitArray::repeat(e.bit_state(), self.bitsize.get())
             }]
         };
 
-        let out = BitArray::from_bits(inp.wrapping_neg(), self.bitsize);
+        let out = BitArray::from_bits(inp.wrapping_neg(), self.bitsize.get());
         vec![PortUpdate { index: 1, value: out }]
     }
 }
@@ -410,7 +410,7 @@ pub enum SignType {
 /// A Comparator component.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Comparator {
-    bitsize: u8,
+    bitsize: BitSize,
     signedness: SignType
 
 }
@@ -418,7 +418,7 @@ impl Comparator {
     /// Creates a new instance of the comparator with specified bitsize.
     pub fn new(bitsize: u8, signedness: SignType) -> Self {
         Self {
-            bitsize: bitsize.clamp(BitArray::MIN_BITSIZE, BitArray::MAX_BITSIZE),
+            bitsize: BitSize::new_clamped(bitsize),
             signedness
         }
     }
@@ -427,7 +427,7 @@ impl Component for Comparator {
     fn ports(&self, _: &CircuitGraphMap) -> Vec<PortProperties> {
         port_list(&[
             // Input
-            (PortProperties { ty: PortType::Input, bitsize: self.bitsize }, 2),
+            (PortProperties { ty: PortType::Input, bitsize: self.bitsize.get() }, 2),
             /*
                 [2] = <
                 [3] = =
@@ -453,7 +453,7 @@ impl Component for Comparator {
         };
 
         let cmp = match self.signedness {
-            SignType::TwosComplement => sign_extend_64(a, self.bitsize).cmp(&sign_extend_64(b, self.bitsize)),
+            SignType::TwosComplement => sign_extend_64(a, self.bitsize.get()).cmp(&sign_extend_64(b, self.bitsize.get())),
             SignType::Unsigned => a.cmp(&b),
         };
         vec![
@@ -478,16 +478,16 @@ pub enum ExtensionType {
 /// A Bit-Extender component.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct BitExtender {
-    in_bitsize: u8,
-    out_bitsize: u8,
+    in_bitsize: BitSize,
+    out_bitsize: BitSize,
     ext_type: ExtensionType
 }
 impl BitExtender {
     /// Creates a new instance of the bitextender with specified bitsize.
-    pub fn new(in_bitsize: u8, out_bitsize:u8, ext_type: ExtensionType) -> Self {
+    pub fn new(in_bitsize: u8, out_bitsize: u8, ext_type: ExtensionType) -> Self {
         Self {
-            in_bitsize: in_bitsize.clamp(BitArray::MIN_BITSIZE, BitArray::MAX_BITSIZE),
-            out_bitsize: out_bitsize.clamp(BitArray::MIN_BITSIZE, BitArray::MAX_BITSIZE),
+            in_bitsize: BitSize::new_clamped(in_bitsize),
+            out_bitsize: BitSize::new_clamped(out_bitsize),
             ext_type
         }
     }
@@ -496,9 +496,9 @@ impl Component for BitExtender {
     fn ports(&self, _: &CircuitGraphMap) -> Vec<PortProperties> {
         port_list(&[
             // Input
-            (PortProperties { ty: PortType::Input, bitsize: self.in_bitsize}, 1),
+            (PortProperties { ty: PortType::Input, bitsize: self.in_bitsize.get() }, 1),
             // Output
-            (PortProperties { ty: PortType::Output, bitsize: self.out_bitsize }, 1),
+            (PortProperties { ty: PortType::Output, bitsize: self.out_bitsize.get() }, 1),
         ])
     }
 
@@ -508,7 +508,7 @@ impl Component for BitExtender {
             ExtensionType::One => BitState::High,
             ExtensionType::Sign => ctx.new_ports[0].get(ctx.new_ports[0].len() - 1).unwrap(),
         };
-        let value = ctx.new_ports[0].resize(self.out_bitsize, fill);
+        let value = ctx.new_ports[0].resize(self.out_bitsize.get(), fill);
 
         vec![PortUpdate { index: 1, value }]
     }
@@ -517,13 +517,13 @@ impl Component for BitExtender {
 /// A Shifter component.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Shifter {
-    bitsize: u8,
+    bitsize: BitSize,
     shift_type: ShiftType
 }
 impl Shifter {
     /// Creates a new instance of the Shifter with specified bitsize.
     pub fn new(bitsize: u8, shift_type: ShiftType) -> Self {
-        let bitsize = bitsize.clamp(BitArray::MIN_BITSIZE, BitArray::MAX_BITSIZE);
+        let bitsize = BitSize::new_clamped(bitsize);
         Self {
             bitsize,
             shift_type
@@ -534,7 +534,7 @@ impl Shifter {
     pub fn shift_bitsize(self) -> u8 {
         // ilog2 ceil
         // doesn't exist in stdlib so we're just gonna hardcode it lol
-        match self.bitsize {
+        match self.bitsize.get() {
             0..=2   => 1,
             3..=4   => 2,
             5..=8   => 3,
@@ -548,18 +548,18 @@ impl Component for Shifter {
     fn ports(&self, _: &CircuitGraphMap) -> Vec<PortProperties> {
         port_list(&[
             // Input
-            (PortProperties { ty: PortType::Input, bitsize: self.bitsize }, 1),
+            (PortProperties { ty: PortType::Input, bitsize: self.bitsize.get() }, 1),
             // Shift
             (PortProperties { ty: PortType::Input, bitsize: self.shift_bitsize() }, 1),
             // Output
-            (PortProperties { ty: PortType::Output, bitsize: self.bitsize }, 1),
+            (PortProperties { ty: PortType::Output, bitsize: self.bitsize.get() }, 1),
         ])
     }
 
     fn run_inner(&self, ctx: RunContext<'_>) -> Vec<PortUpdate> {
         let a = ctx.new_ports[0];
         let Ok(b) = u64::try_from(ctx.new_ports[1]) else {
-            return vec![PortUpdate { index: 2, value: bitarr![X; self.bitsize] }]
+            return vec![PortUpdate { index: 2, value: bitarr![X; self.bitsize.get()] }]
         };
         
         vec![PortUpdate { index: 2, value: a.shift(b as u32, self.shift_type) }]

--- a/packages/backend/src/engine/func/gates.rs
+++ b/packages/backend/src/engine/func/gates.rs
@@ -1,11 +1,13 @@
-use crate::bitarray::{BitArray, BitState, bitarr};
+use crate::bitarray::{BitArray, BitState, RangedByte, bitarr};
 use crate::engine::CircuitGraphMap;
-use crate::engine::func::{Component, PortProperties, PortType, PortUpdate, RunContext, port_list};
+use crate::engine::func::{BitSize, Component, PortProperties, PortType, PortUpdate, RunContext, port_list};
 
 /// Minimum number of inputs for multi-input logic gates.
 pub const MIN_GATE_INPUTS: u8 = 2;
 /// Maximum number of inputs for multi-input logic gates.
 pub const MAX_GATE_INPUTS: u8 = 64;
+
+pub(crate) type GateInputs = RangedByte<MIN_GATE_INPUTS, MAX_GATE_INPUTS>;
 
 /// The gate type for [`Gate`].
 /// 
@@ -36,16 +38,16 @@ impl GateKind {
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Gate {
     kind: GateKind,
-    bitsize: u8,
-    n_inputs: u8
+    bitsize: BitSize,
+    n_inputs: GateInputs
 }
 impl Gate {
     /// Creates a new instance of the gate with specified bitsize and number of inputs.
     pub fn new(kind: GateKind, bitsize: u8, n_inputs: u8) -> Self {
         Self {
             kind,
-            bitsize: bitsize.clamp(BitArray::MIN_BITSIZE, BitArray::MAX_BITSIZE),
-            n_inputs: n_inputs.clamp(MIN_GATE_INPUTS, MAX_GATE_INPUTS)
+            bitsize: BitSize::new_clamped(bitsize),
+            n_inputs: GateInputs::new_clamped(n_inputs)
         }
     }
 
@@ -55,27 +57,27 @@ impl Gate {
     }
     /// Returns the number of inputs for this gate.
     pub fn n_inputs(&self) -> u8 {
-        self.n_inputs
+        self.n_inputs.get()
     }
     /// Returns the bitsize for this gate.
     pub fn bitsize(&self) -> u8 {
-        self.bitsize
+        self.bitsize.get()
     }
 }
 impl Component for Gate {
     fn ports(&self, _: &CircuitGraphMap) -> Vec<PortProperties> {
         port_list(&[
             // inputs
-            (PortProperties { ty: PortType::Input, bitsize: self.bitsize }, usize::from(self.n_inputs)),
+            (PortProperties { ty: PortType::Input, bitsize: self.bitsize.get() }, usize::from(self.n_inputs)),
             // outputs
-            (PortProperties { ty: PortType::Output, bitsize: self.bitsize }, 1),
+            (PortProperties { ty: PortType::Output, bitsize: self.bitsize.get() }, 1),
         ])
     }
 
     fn run_inner(&self, ctx: RunContext<'_>) -> Vec<PortUpdate> {
         let inputs = ctx.new_ports[..usize::from(self.n_inputs)].iter().cloned();
         let output = self.kind.reduce(inputs)
-            .unwrap_or_else(|| bitarr![X; self.bitsize]);
+            .unwrap_or_else(|| bitarr![X; self.bitsize.get()]);
         
         vec![PortUpdate {
             index: usize::from(self.n_inputs),
@@ -87,13 +89,13 @@ impl Component for Gate {
 /// A NOT gate component.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Not {
-    bitsize: u8
+    bitsize: BitSize
 }
 impl Not {
     /// Creates a new instance of the NOT gate with specified bitsize.
     pub fn new(bitsize: u8) -> Self {
         Self {
-            bitsize: bitsize.clamp(BitArray::MIN_BITSIZE, BitArray::MAX_BITSIZE)
+            bitsize: BitSize::new_clamped(bitsize)
         }
     }
 }
@@ -101,9 +103,9 @@ impl Component for Not {
     fn ports(&self, _: &CircuitGraphMap) -> Vec<PortProperties> {
         port_list(&[
             // input
-            (PortProperties { ty: PortType::Input, bitsize: self.bitsize }, 1),
+            (PortProperties { ty: PortType::Input, bitsize: self.bitsize.get() }, 1),
             // output
-            (PortProperties { ty: PortType::Output, bitsize: self.bitsize }, 1),
+            (PortProperties { ty: PortType::Output, bitsize: self.bitsize.get() }, 1),
         ])
     }
 
@@ -116,13 +118,13 @@ impl Component for Not {
 /// A tri-state buffer component.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct TriState {
-    bitsize: u8
+    bitsize: BitSize
 }
 impl TriState {
     /// Creates a new instance of the tri-state buffer with specified bitsize.
     pub fn new(bitsize: u8) -> Self {
         Self {
-            bitsize: bitsize.clamp(BitArray::MIN_BITSIZE, BitArray::MAX_BITSIZE)
+            bitsize: BitSize::new_clamped(bitsize)
         }
     }
 }
@@ -132,9 +134,9 @@ impl Component for TriState {
             // selector
             (PortProperties { ty: PortType::Input, bitsize: 1 }, 1),
             // input
-            (PortProperties { ty: PortType::Input, bitsize: self.bitsize }, 1),
+            (PortProperties { ty: PortType::Input, bitsize: self.bitsize.get() }, 1),
             // output
-            (PortProperties { ty: PortType::Output, bitsize: self.bitsize }, 1),
+            (PortProperties { ty: PortType::Output, bitsize: self.bitsize.get() }, 1),
         ])
     }
 
@@ -142,8 +144,8 @@ impl Component for TriState {
         let gate = ctx.new_ports[0].index(0);
         let result = match gate {
             BitState::High => ctx.new_ports[1],
-            BitState::Low | BitState::Imped => bitarr![Z; self.bitsize],
-            BitState::Unk => bitarr![X; self.bitsize],
+            BitState::Low | BitState::Imped => bitarr![Z; self.bitsize.get()],
+            BitState::Unk => bitarr![X; self.bitsize.get()],
         };
         vec![PortUpdate { index: 2, value: result }]
     }

--- a/packages/backend/src/engine/func/gates.rs
+++ b/packages/backend/src/engine/func/gates.rs
@@ -11,7 +11,7 @@ pub const MAX_GATE_INPUTS: u8 = 64;
 /// 
 /// This defines the logic and appearance of the gate.
 #[expect(missing_docs)]
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, strum::IntoStaticStr)]
 pub enum GateKind {
     And, Or, Xor, Nand, Nor, Xnor
 }
@@ -28,18 +28,6 @@ impl GateKind {
             GateKind::Nand => it.reduce(|a, b| a & b).map(|r| !r),
             GateKind::Nor  => it.reduce(|a, b| a | b).map(|r| !r),
             GateKind::Xnor => it.reduce(|a, b| a ^ b).map(|r| !r),
-        }
-    }
-
-    /// The name of the gate.
-    pub fn name(self) -> &'static str {
-        match self {
-            GateKind::And  => "And",
-            GateKind::Or   => "Or",
-            GateKind::Xor  => "Xor",
-            GateKind::Nand => "Nand",
-            GateKind::Nor  => "Nor",
-            GateKind::Xnor => "Xnor",
         }
     }
 }

--- a/packages/backend/src/engine/func/gates.rs
+++ b/packages/backend/src/engine/func/gates.rs
@@ -12,6 +12,7 @@ pub const MAX_GATE_INPUTS: u8 = 64;
 /// This defines the logic and appearance of the gate.
 #[expect(missing_docs)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, strum::IntoStaticStr)]
+#[cfg_attr(feature="serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum GateKind {
     And, Or, Xor, Nand, Nor, Xnor
 }

--- a/packages/backend/src/engine/func/memory.rs
+++ b/packages/backend/src/engine/func/memory.rs
@@ -1,18 +1,18 @@
 use crate::bitarr;
 use crate::bitarray::{BitArray, BitState};
 use crate::engine::CircuitGraphMap;
-use crate::engine::func::{Component, PortProperties, PortType, PortUpdate, RunContext, Sensitivity, port_list};
+use crate::engine::func::{BitSize, Component, PortProperties, PortType, PortUpdate, RunContext, Sensitivity, port_list};
 
 /// A register component.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Register {
-    bitsize: u8
+    bitsize: BitSize
 }
 impl Register {
     /// Creates a new instance of the Register with specified bitsize.
     pub fn new(bitsize: u8) -> Self {
         Self {
-            bitsize: bitsize.clamp(BitArray::MIN_BITSIZE, BitArray::MAX_BITSIZE)
+            bitsize: BitSize::new_clamped(bitsize)
         }
     }
 }
@@ -20,19 +20,19 @@ impl Component for Register {
     fn ports(&self, _: &CircuitGraphMap) -> Vec<PortProperties> {
         port_list(&[
             // din
-            (PortProperties { ty: PortType::Input, bitsize: self.bitsize }, 1),
+            (PortProperties { ty: PortType::Input, bitsize: self.bitsize.get() }, 1),
             // enable, clock, clear
             (PortProperties { ty: PortType::Input, bitsize: 1 }, 3),
             // dout
-            (PortProperties { ty: PortType::Output, bitsize: self.bitsize }, 1),
+            (PortProperties { ty: PortType::Output, bitsize: self.bitsize.get() }, 1),
         ])
     }
     fn initialize_port_state(&self, state: &mut [BitArray]) {
-        state[4] = bitarr![0; self.bitsize];
+        state[4] = bitarr![0; self.bitsize.get()];
     }
     fn run_inner(&self, ctx: RunContext<'_>) -> Vec<PortUpdate> {
         if ctx.new_ports[3].all(BitState::High) {
-            vec![PortUpdate { index: 4, value: bitarr![0; self.bitsize] }]
+            vec![PortUpdate { index: 4, value: bitarr![0; self.bitsize.get()] }]
         } else if Sensitivity::Posedge.activated(ctx.old_ports[2], ctx.new_ports[2]) && ctx.new_ports[1].all(BitState::High) {
             vec![PortUpdate { index: 4, value: ctx.new_ports[0] }]
         } else {

--- a/packages/backend/src/engine/func/mod.rs
+++ b/packages/backend/src/engine/func/mod.rs
@@ -9,7 +9,7 @@
 //! - **[`PortType`] and [`PortProperties`]**: Enumerations and structures to define the types and properties of ports for components.
 //! - **[`PortUpdate`]**: A structure representing updates to port values during simulation.
 //! - **Digital Logic Components**: Implementations of basic logic components used to simulate digital circuits.
-use crate::bitarray::{BitArray, BitState};
+use crate::bitarray::{BitArray, BitState, RangedByte};
 use crate::engine::CircuitGraphMap;
 use crate::engine::state::InnerFunctionState;
 
@@ -239,3 +239,5 @@ fn floating_ports(properties: &[PortProperties]) -> Vec<BitArray> {
         .map(|p| bitarr![Z; p.bitsize])
         .collect()
 }
+
+pub(crate) type BitSize = RangedByte<{ BitArray::MIN_BITSIZE }, { BitArray::MAX_BITSIZE }>;

--- a/packages/backend/src/engine/func/muxes.rs
+++ b/packages/backend/src/engine/func/muxes.rs
@@ -23,9 +23,12 @@ impl Mux {
         }
     }
 
+    pub(crate) fn n_inputs_from(selsize: u8) -> usize {
+        1 << selsize
+    }
     /// The number of inputs.
     pub fn n_inputs(self) -> usize {
-        1 << self.selsize
+        Mux::n_inputs_from(self.selsize)
     }
 }
 impl Component for Mux {
@@ -65,9 +68,12 @@ impl Demux {
         }
     }
 
+    pub(crate) fn n_outputs_from(selsize: u8) -> usize {
+        1 << selsize
+    }
     /// The number of outputs.
     pub fn n_outputs(self) -> usize {
-        1 << self.selsize
+        Demux::n_outputs_from(self.selsize)
     }
 }
 impl Component for Demux {
@@ -112,9 +118,12 @@ impl Decoder {
         }
     }
 
+    pub(crate) fn n_outputs_from(selsize: u8) -> usize {
+        1 << selsize
+    }
     /// The number of outputs
     pub fn n_outputs(self) -> usize {
-        1 << self.selsize
+        Self::n_outputs_from(self.selsize)
     }
 }
 impl Component for Decoder {

--- a/packages/backend/src/engine/func/muxes.rs
+++ b/packages/backend/src/engine/func/muxes.rs
@@ -1,6 +1,7 @@
 
+use crate::bitarray::RangedByte;
 use crate::engine::CircuitGraphMap;
-use crate::engine::func::{Component, PortProperties, PortType, PortUpdate, RunContext, port_list};
+use crate::engine::func::{BitSize, Component, PortProperties, PortType, PortUpdate, RunContext, port_list};
 use crate::{bitarr, bitarray::BitArray};
 
 /// Minimum number of selector bits for Mux/Demux/Decoder.
@@ -8,23 +9,25 @@ pub const MIN_SELSIZE: u8 = 1;
 /// Maximum number of selector bits for Mux/Demux/Decoder.
 pub const MAX_SELSIZE: u8 = 6;
 
+pub(crate) type SelSize = RangedByte<{ MIN_SELSIZE }, { MAX_SELSIZE }>;
+
 /// A multiplexer (mux) component.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Mux {
-    bitsize: u8,
-    selsize: u8
+    bitsize: BitSize,
+    selsize: SelSize
 }
 impl Mux {
     /// Creates a new instance of the Mux with specified bitsize and selector size.
     pub fn new(bitsize: u8, selsize: u8) -> Self {
         Self {
-            bitsize: bitsize.clamp(BitArray::MIN_BITSIZE, BitArray::MAX_BITSIZE),
-            selsize: selsize.clamp(MIN_SELSIZE, MAX_SELSIZE)
+            bitsize: BitSize::new_clamped(bitsize),
+            selsize: SelSize::new_clamped(selsize)
         }
     }
 
-    pub(crate) fn n_inputs_from(selsize: u8) -> usize {
-        1 << selsize
+    pub(crate) fn n_inputs_from(selsize: SelSize) -> usize {
+        1 << selsize.get()
     }
     /// The number of inputs.
     pub fn n_inputs(self) -> usize {
@@ -35,11 +38,11 @@ impl Component for Mux {
     fn ports(&self, _: &CircuitGraphMap) -> Vec<PortProperties> {
         port_list(&[
             // selector
-            (PortProperties { ty: PortType::Input, bitsize: self.selsize }, 1),
+            (PortProperties { ty: PortType::Input, bitsize: self.selsize.get() }, 1),
             // inputs
-            (PortProperties { ty: PortType::Input, bitsize: self.bitsize }, self.n_inputs()),
+            (PortProperties { ty: PortType::Input, bitsize: self.bitsize.get() }, self.n_inputs()),
             // output
-            (PortProperties { ty: PortType::Output, bitsize: self.bitsize }, 1),
+            (PortProperties { ty: PortType::Output, bitsize: self.bitsize.get() }, 1),
         ])
     }
 
@@ -47,7 +50,7 @@ impl Component for Mux {
         let m_sel = u64::try_from(ctx.new_ports[0]);
         let result = match m_sel {
             Ok(sel) => ctx.new_ports[sel as usize + 1],
-            Err(e) => BitArray::repeat(e.bit_state(), self.bitsize),
+            Err(e) => BitArray::repeat(e.bit_state(), self.bitsize.get()),
         };
         vec![PortUpdate { index: 1 + self.n_inputs(), value: result }]
     }
@@ -56,20 +59,20 @@ impl Component for Mux {
 /// A demultiplexer (demux) component.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Demux {
-    bitsize: u8,
-    selsize: u8
+    bitsize: BitSize,
+    selsize: SelSize
 }
 impl Demux {
     /// Creates a new instance of the Demux with specified bitsize and selector size.
     pub fn new(bitsize: u8, selsize: u8) -> Self {
         Self {
-            bitsize: bitsize.clamp(BitArray::MIN_BITSIZE, BitArray::MAX_BITSIZE),
-            selsize: selsize.clamp(MIN_SELSIZE, MAX_SELSIZE)
+            bitsize: BitSize::new_clamped(bitsize),
+            selsize: SelSize::new_clamped(selsize)
         }
     }
 
-    pub(crate) fn n_outputs_from(selsize: u8) -> usize {
-        1 << selsize
+    pub(crate) fn n_outputs_from(selsize: SelSize) -> usize {
+        1 << selsize.get()
     }
     /// The number of outputs.
     pub fn n_outputs(self) -> usize {
@@ -80,22 +83,22 @@ impl Component for Demux {
     fn ports(&self, _: &CircuitGraphMap) -> Vec<PortProperties> {
             port_list(&[
             // selector
-            (PortProperties { ty: PortType::Input, bitsize: self.selsize }, 1),
+            (PortProperties { ty: PortType::Input, bitsize: self.selsize.get() }, 1),
             // input
-            (PortProperties { ty: PortType::Input, bitsize: self.bitsize }, 1),
+            (PortProperties { ty: PortType::Input, bitsize: self.bitsize.get() }, 1),
             // outputs
-            (PortProperties { ty: PortType::Output, bitsize: self.bitsize }, self.n_outputs()),
+            (PortProperties { ty: PortType::Output, bitsize: self.bitsize.get() }, self.n_outputs()),
         ])
     }
     fn run_inner(&self, ctx: RunContext<'_>) -> Vec<PortUpdate> {
         let m_sel = u64::try_from(ctx.new_ports[0]);
         let result = match m_sel {
             Ok(sel) => {
-                let mut result = vec![bitarr![0; self.bitsize]; self.n_outputs()];
+                let mut result = vec![bitarr![0; self.bitsize.get()]; self.n_outputs()];
                 result[sel as usize] = ctx.new_ports[1];
                 result
             },
-            Err(e) => vec![BitArray::repeat(e.bit_state(), self.bitsize); self.n_outputs()],
+            Err(e) => vec![BitArray::repeat(e.bit_state(), self.bitsize.get()); self.n_outputs()],
         };
 
         result.into_iter()
@@ -108,18 +111,18 @@ impl Component for Demux {
 /// A decoder component.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Decoder {
-    selsize: u8
+    selsize: SelSize
 }
 impl Decoder {
     /// Creates a new instance of the Decoder with specified selector size.
     pub fn new(selsize: u8) -> Self {
         Self {
-            selsize: selsize.clamp(MIN_SELSIZE, MAX_SELSIZE)
+            selsize: SelSize::new_clamped(selsize)
         }
     }
 
-    pub(crate) fn n_outputs_from(selsize: u8) -> usize {
-        1 << selsize
+    pub(crate) fn n_outputs_from(selsize: SelSize) -> usize {
+        1 << selsize.get()
     }
     /// The number of outputs
     pub fn n_outputs(self) -> usize {
@@ -130,7 +133,7 @@ impl Component for Decoder {
     fn ports(&self, _: &CircuitGraphMap) -> Vec<PortProperties> {
         port_list(&[
             // selector
-            (PortProperties { ty: PortType::Input, bitsize: self.selsize }, 1),
+            (PortProperties { ty: PortType::Input, bitsize: self.selsize.get() }, 1),
             // outputs
             (PortProperties { ty: PortType::Output, bitsize: 1 }, self.n_outputs()),
         ])

--- a/packages/backend/src/engine/func/wiring.rs
+++ b/packages/backend/src/engine/func/wiring.rs
@@ -1,30 +1,30 @@
 use crate::bitarray::BitArray;
 use crate::engine::CircuitGraphMap;
-use crate::engine::func::{Component, PortProperties, PortType, PortUpdate, RunContext, Sensitivity, port_list};
+use crate::engine::func::{BitSize, Component, PortProperties, PortType, PortUpdate, RunContext, Sensitivity, port_list};
 
 /// An input.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Input {
-    bitsize: u8
+    bitsize: BitSize
 }
 impl Input {
     /// Creates a new instance of the tri-state buffer with specified bitsize.
     pub fn new(bitsize: u8) -> Self {
         Self {
-            bitsize: bitsize.clamp(BitArray::MIN_BITSIZE, BitArray::MAX_BITSIZE)
+            bitsize: BitSize::new_clamped(bitsize)
         }
     }
 
     /// Gets the bitsize of this component.
     pub fn get_bitsize(&self) -> u8 {
-        self.bitsize
+        self.bitsize.get()
     }
 }
 impl Component for Input {
     fn ports(&self, _: &CircuitGraphMap) -> Vec<PortProperties> {
         port_list(&[
             // output
-            (PortProperties { ty: PortType::Output, bitsize: self.bitsize }, 1),
+            (PortProperties { ty: PortType::Output, bitsize: self.bitsize.get() }, 1),
         ])
     }
 
@@ -36,26 +36,26 @@ impl Component for Input {
 /// An output.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Output {
-    bitsize: u8
+    bitsize: BitSize
 }
 impl Output {
     /// Creates a new instance of the tri-state buffer with specified bitsize.
     pub fn new(bitsize: u8) -> Self {
         Self {
-            bitsize: bitsize.clamp(BitArray::MIN_BITSIZE, BitArray::MAX_BITSIZE)
+            bitsize: BitSize::new_clamped(bitsize)
         }
     }
 
     /// Gets the bitsize of this component.
     pub fn get_bitsize(&self) -> u8 {
-        self.bitsize
+        self.bitsize.get()
     }
 }
 impl Component for Output {
     fn ports(&self, _: &CircuitGraphMap) -> Vec<PortProperties> {
         port_list(&[
             // output
-            (PortProperties { ty: PortType::Input, bitsize: self.bitsize }, 1),
+            (PortProperties { ty: PortType::Input, bitsize: self.bitsize.get() }, 1),
         ])
     }
 
@@ -99,26 +99,26 @@ impl Component for Constant {
 /// A splitter component.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Splitter {
-    bitsize: u8
+    bitsize: BitSize
 }
 impl Splitter {
     /// Creates a new instance of the Splitter with specified bitsize.
     pub fn new(bitsize: u8) -> Self {
         Self {
-            bitsize: bitsize.clamp(BitArray::MIN_BITSIZE, BitArray::MAX_BITSIZE)
+            bitsize: BitSize::new_clamped(bitsize)
         }
     }
 
     /// Gets the bitsize of this component.
     pub fn get_bitsize(&self) -> u8 {
-        self.bitsize
+        self.bitsize.get()
     }
 }
 impl Component for Splitter {
     fn ports(&self, _: &CircuitGraphMap) -> Vec<PortProperties> {
         port_list(&[
             // joined
-            (PortProperties { ty: PortType::Inout, bitsize: self.bitsize }, 1),
+            (PortProperties { ty: PortType::Inout, bitsize: self.bitsize.get() }, 1),
             // split
             (PortProperties { ty: PortType::Inout, bitsize: 1 }, usize::from(self.bitsize)),
         ])

--- a/packages/backend/src/middle_end/func/gates.rs
+++ b/packages/backend/src/middle_end/func/gates.rs
@@ -1,4 +1,4 @@
-use crate::engine::func;
+use crate::engine::func::{self, BitSize, GateInputs};
 use crate::middle_end::func::{AbsoluteComponentBounds, Orientation, PhysicalComponent, PhysicalInitContext, RelativeComponentBounds};
 
 pub use func::GateKind;
@@ -8,13 +8,13 @@ pub use func::GateKind;
 #[cfg_attr(feature="serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Gate {
     kind: GateKind,
-    bitsize: u8,
-    n_inputs: u8,
+    bitsize: BitSize,
+    n_inputs: GateInputs,
     orientation: Orientation
 }
 impl PhysicalComponent for Gate {
     fn init_engine(&self) -> Option<func::ComponentFn> {
-        Some(func::Gate::new(self.kind, self.bitsize, self.n_inputs).into())
+        Some(func::Gate::new(self.kind, self.bitsize.get(), self.n_inputs.get()).into())
     }
 
     fn component_name(&self) -> &'static str {
@@ -24,7 +24,7 @@ impl PhysicalComponent for Gate {
     fn init_bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
         // The origin is at the output port, which is at (4,2) in absolute coordinates.
         let bounds = [(-4, -2), (0, 2)];
-        let inputs = i32::from(self.n_inputs);
+        let inputs = i32::from(self.n_inputs.get());
         
         let mut ports = vec![];
         // Input ports
@@ -42,13 +42,13 @@ impl PhysicalComponent for Gate {
 #[cfg_attr(feature="serde", derive(serde::Serialize, serde::Deserialize))]
 /// A NOT gate component.
 pub struct Not {
-    bitsize: u8,
+    bitsize: BitSize,
     orientation: Orientation
 }
 
 impl PhysicalComponent for Not {
     fn init_engine(&self) -> Option<func::ComponentFn> {
-        Some(func::Not::new(self.bitsize).into())
+        Some(func::Not::new(self.bitsize.get()).into())
     }
 
     fn component_name(&self) -> &'static str {
@@ -67,13 +67,13 @@ impl PhysicalComponent for Not {
 #[cfg_attr(feature="serde", derive(serde::Serialize, serde::Deserialize))]
 /// A tri-state buffer.
 pub struct TriState {
-    bitsize: u8,
+    bitsize: BitSize,
     orientation: Orientation
 }
 
 impl PhysicalComponent for TriState {
     fn init_engine(&self) -> Option<func::ComponentFn> {
-        Some(func::TriState::new(self.bitsize).into())
+        Some(func::TriState::new(self.bitsize.get()).into())
     }
 
     fn component_name(&self) -> &'static str {

--- a/packages/backend/src/middle_end/func/gates.rs
+++ b/packages/backend/src/middle_end/func/gates.rs
@@ -5,6 +5,7 @@ pub use func::GateKind;
 
 /// A gate component with a variable number of inputs.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[cfg_attr(feature="serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Gate {
     kind: GateKind,
     bitsize: u8,
@@ -38,6 +39,7 @@ impl PhysicalComponent for Gate {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[cfg_attr(feature="serde", derive(serde::Serialize, serde::Deserialize))]
 /// A NOT gate component.
 pub struct Not {
     bitsize: u8,
@@ -62,6 +64,7 @@ impl PhysicalComponent for Not {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[cfg_attr(feature="serde", derive(serde::Serialize, serde::Deserialize))]
 /// A tri-state buffer.
 pub struct TriState {
     bitsize: u8,

--- a/packages/backend/src/middle_end/func/gates.rs
+++ b/packages/backend/src/middle_end/func/gates.rs
@@ -1,26 +1,29 @@
 use crate::engine::func;
-use crate::middle_end::func::{AbsoluteComponentBounds, PhysicalComponent, PhysicalInitContext, RelativeComponentBounds};
+use crate::middle_end::func::{AbsoluteComponentBounds, Orientation, PhysicalComponent, PhysicalInitContext, RelativeComponentBounds};
 
 pub use func::GateKind;
 
 /// A gate component with a variable number of inputs.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Gate {
-    sim: func::Gate
+    kind: GateKind,
+    bitsize: u8,
+    n_inputs: u8,
+    orientation: Orientation
 }
 impl PhysicalComponent for Gate {
-    fn engine_component(&self) -> Option<func::ComponentFn> {
-        Some(self.sim.into())
+    fn init_engine(&self) -> Option<func::ComponentFn> {
+        Some(func::Gate::new(self.kind, self.bitsize, self.n_inputs).into())
     }
 
     fn component_name(&self) -> &'static str {
-        self.sim.kind().into()
+        self.kind.into()
     }
 
-    fn bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
+    fn init_bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
         // The origin is at the output port, which is at (4,2) in absolute coordinates.
         let bounds = [(-4, -2), (0, 2)];
-        let inputs = self.sim.n_inputs() as i32;
+        let inputs = i32::from(self.n_inputs);
         
         let mut ports = vec![];
         // Input ports
@@ -30,49 +33,54 @@ impl PhysicalComponent for Gate {
         ports.push((0, 0)); // Output port
 
         RelativeComponentBounds { bounds, ports }
+            .orient(self.orientation, Default::default())
     }
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 /// A NOT gate component.
 pub struct Not {
-    sim: func::Not,
+    bitsize: u8,
+    orientation: Orientation
 }
 
 impl PhysicalComponent for Not {
-    fn engine_component(&self) -> Option<func::ComponentFn> {
-        Some(self.sim.into())
+    fn init_engine(&self) -> Option<func::ComponentFn> {
+        Some(func::Not::new(self.bitsize).into())
     }
 
     fn component_name(&self) -> &'static str {
         "Not"
     }
 
-    fn bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
+    fn init_bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
         let origin = (3, 1);
         AbsoluteComponentBounds::new((3, 2), [(0, 1), origin])
             .into_relative(origin)
+            .orient(self.orientation, Default::default())
     }
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 /// A tri-state buffer.
 pub struct TriState {
-    sim: func::TriState,
+    bitsize: u8,
+    orientation: Orientation
 }
 
 impl PhysicalComponent for TriState {
-    fn engine_component(&self) -> Option<func::ComponentFn> {
-        Some(self.sim.into())
+    fn init_engine(&self) -> Option<func::ComponentFn> {
+        Some(func::TriState::new(self.bitsize).into())
     }
 
     fn component_name(&self) -> &'static str {
         "TriState"
     }
 
-    fn bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
+    fn init_bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
         let origin = (2, 1);
         AbsoluteComponentBounds::new((2, 2), [(0, 1), (1, 2), origin])
             .into_relative(origin)
+            .orient(self.orientation, Default::default())
     }
 }

--- a/packages/backend/src/middle_end/func/gates.rs
+++ b/packages/backend/src/middle_end/func/gates.rs
@@ -14,7 +14,7 @@ impl PhysicalComponent for Gate {
     }
 
     fn component_name(&self) -> &'static str {
-        self.sim.kind().name()
+        self.sim.kind().into()
     }
 
     fn bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {

--- a/packages/backend/src/middle_end/func/misc.rs
+++ b/packages/backend/src/middle_end/func/misc.rs
@@ -1,21 +1,21 @@
-use crate::engine::func;
+use crate::engine::{CircuitKey, func};
 use crate::middle_end::func::{PhysicalComponent, PhysicalInitContext, RelativeComponentBounds};
 
 /// A subcircuit component.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Subcircuit {
-    sim: func::Subcircuit
+    key: CircuitKey
 }
 impl PhysicalComponent for Subcircuit {
-    fn engine_component(&self) -> Option<func::ComponentFn> {
-        Some(self.sim.into())
+    fn init_engine(&self) -> Option<func::ComponentFn> {
+        Some(func::Subcircuit::new(self.key).into())
     }
 
     fn component_name(&self) ->  &'static str {
         "Subcircuit"
     }
 
-    fn bounds(&self, ctx: PhysicalInitContext<'_>) -> RelativeComponentBounds {
+    fn init_bounds(&self, ctx: PhysicalInitContext<'_>) -> RelativeComponentBounds {
         todo!()
     }
 }
@@ -24,7 +24,7 @@ impl PhysicalComponent for Subcircuit {
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Text;
 impl PhysicalComponent for Text {
-    fn engine_component(&self) -> Option<func::ComponentFn> {
+    fn init_engine(&self) -> Option<func::ComponentFn> {
         None
     }
 
@@ -32,7 +32,7 @@ impl PhysicalComponent for Text {
         "Text"
     }
 
-    fn bounds(&self, ctx: PhysicalInitContext<'_>) -> RelativeComponentBounds {
+    fn init_bounds(&self, ctx: PhysicalInitContext<'_>) -> RelativeComponentBounds {
         todo!()
     }
 }

--- a/packages/backend/src/middle_end/func/misc.rs
+++ b/packages/backend/src/middle_end/func/misc.rs
@@ -1,6 +1,7 @@
 use crate::engine::{CircuitKey, func};
 use crate::middle_end::func::{PhysicalComponent, PhysicalInitContext, RelativeComponentBounds};
 
+// FIXME: This deser def'n no longer works
 /// A subcircuit component.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Subcircuit {
@@ -19,9 +20,44 @@ impl PhysicalComponent for Subcircuit {
         todo!()
     }
 }
+#[cfg(feature="serde")]
+mod subcircuit_serde {
+    use serde::{Deserialize, Serialize};
+    
+    use crate::middle_end::MiddleRepr;
+    use crate::middle_end::func::Subcircuit;
+    use crate::middle_end::func::pcom_serde::PComDeserCtx;
+    use crate::middle_end::serialize::{DeserializeWithCtx, SerializeWithCtx};
+
+    #[derive(Serialize, Deserialize)]
+    struct SubcircuitSer<'a> {
+        subcircuit: &'a str
+    }
+
+    impl SerializeWithCtx<MiddleRepr> for Subcircuit {
+        fn serialize_with_ctx<S>(&self, ctx: &MiddleRepr, serializer: S) -> Result<S::Ok, S::Error>
+            where S: serde::Serializer
+        {
+            let subcircuit = &ctx.physical[self.key].name;
+            SubcircuitSer { subcircuit }.serialize(serializer)
+        }
+    }
+
+    impl<'de> DeserializeWithCtx<'de, PComDeserCtx<'de>> for Subcircuit {
+        fn deserialize_with_ctx<D>(ctx: PComDeserCtx<'de>, deserializer: D) -> Result<Self, D::Error>
+            where D: serde::Deserializer<'de>
+        {
+            let SubcircuitSer { subcircuit } = SubcircuitSer::deserialize(deserializer)?;
+            ctx.circuit_map.get(subcircuit)
+                .map(|&key| Subcircuit { key })
+                .ok_or_else(|| serde::de::Error::custom(format!("no circuit exists with name {subcircuit}")))
+        }
+    }
+}
 
 /// Text.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[cfg_attr(feature="serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Text;
 impl PhysicalComponent for Text {
     fn init_engine(&self) -> Option<func::ComponentFn> {

--- a/packages/backend/src/middle_end/func/mod.rs
+++ b/packages/backend/src/middle_end/func/mod.rs
@@ -42,6 +42,7 @@ fn orient_coord(c: CoordDelta, orientation: Orientation, handedness: Handedness)
 /// This is typically used to describe the orientation of a component which can be rotated.
 #[expect(missing_docs)]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy, Default)]
+#[cfg_attr(feature="serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Orientation {
     North, South, #[default] East, West
 }
@@ -58,6 +59,7 @@ pub enum Orientation {
 /// 
 /// We will refer to this as the "chiral" port.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy, Default)]
+#[cfg_attr(feature="serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Handedness {
     /// Left-handedness.
     /// 
@@ -229,7 +231,8 @@ impl AbsoluteComponentBounds {
 #[strum_discriminants(
     name(PhysicalComponentKind),
     expect(missing_docs),
-    derive(strum::IntoStaticStr)
+    derive(strum::IntoStaticStr),
+    cfg_attr(feature="serde", derive(serde::Serialize, serde::Deserialize))
 )]
 pub enum PhysicalComponentEnum {
     // Wiring
@@ -241,6 +244,70 @@ pub enum PhysicalComponentEnum {
     //Gates
     Gate, Not, TriState,
 }
+#[cfg(feature="serde")]
+mod pcom_serde {
+    use std::collections::HashMap;
+
+    use crate::engine::CircuitKey;
+    use crate::middle_end::MiddleRepr;
+    use crate::middle_end::func::{self, PhysicalComponentEnum, PhysicalComponentKind};
+    use crate::middle_end::serialize::{DeserializeWithCtx, SerializeWithCtx};
+
+    impl SerializeWithCtx<MiddleRepr> for PhysicalComponentEnum {
+        fn serialize_with_ctx<S>(&self, ctx: &MiddleRepr, serializer: S) -> Result<S::Ok, S::Error>
+            where S: serde::Serializer
+        {
+            // Equivalent to an untagged serialization
+            match self {
+                PhysicalComponentEnum::Pin(pin) => pin.serialize_with_ctx(ctx, serializer),
+                PhysicalComponentEnum::Constant(constant) => constant.serialize_with_ctx(ctx, serializer),
+                PhysicalComponentEnum::Splitter(splitter) => splitter.serialize_with_ctx(ctx, serializer),
+                PhysicalComponentEnum::Power(power) => power.serialize_with_ctx(ctx, serializer),
+                PhysicalComponentEnum::Ground(ground) => ground.serialize_with_ctx(ctx, serializer),
+                PhysicalComponentEnum::Tunnel(tunnel) => tunnel.serialize_with_ctx(ctx, serializer),
+                PhysicalComponentEnum::Probe(probe) => probe.serialize_with_ctx(ctx, serializer),
+                PhysicalComponentEnum::Mux(mux) => mux.serialize_with_ctx(ctx, serializer),
+                PhysicalComponentEnum::Demux(demux) => demux.serialize_with_ctx(ctx, serializer),
+                PhysicalComponentEnum::Decoder(decoder) => decoder.serialize_with_ctx(ctx, serializer),
+                PhysicalComponentEnum::Text(text) => text.serialize_with_ctx(ctx, serializer),
+                PhysicalComponentEnum::Subcircuit(subcircuit) => subcircuit.serialize_with_ctx(ctx, serializer),
+                PhysicalComponentEnum::Gate(gate) => gate.serialize_with_ctx(ctx, serializer),
+                PhysicalComponentEnum::Not(not) => not.serialize_with_ctx(ctx, serializer),
+                PhysicalComponentEnum::TriState(tri_state) => tri_state.serialize_with_ctx(ctx, serializer),
+            }
+        }
+    }
+
+    pub struct PComDeserCtx<'a> {
+        pub kind: PhysicalComponentKind,
+        pub circuit_map: &'a HashMap<String, CircuitKey>
+    }
+    impl<'de> DeserializeWithCtx<'de, PComDeserCtx<'de>> for PhysicalComponentEnum {
+        fn deserialize_with_ctx<D>(ctx: PComDeserCtx<'de>, deserializer: D) -> Result<Self, D::Error>
+            where D: serde::Deserializer<'de>
+        {
+            match ctx.kind {
+                // FIXME: Make this automatically generated
+                PhysicalComponentKind::Pin => func::Pin::deserialize_with_ctx(ctx, deserializer).map(Into::into),
+                PhysicalComponentKind::Constant => func::Constant::deserialize_with_ctx(ctx, deserializer).map(Into::into),
+                PhysicalComponentKind::Splitter => func::Splitter::deserialize_with_ctx(ctx, deserializer).map(Into::into),
+                PhysicalComponentKind::Power => func::Power::deserialize_with_ctx(ctx, deserializer).map(Into::into),
+                PhysicalComponentKind::Ground => func::Ground::deserialize_with_ctx(ctx, deserializer).map(Into::into),
+                PhysicalComponentKind::Tunnel => func::Tunnel::deserialize_with_ctx(ctx, deserializer).map(Into::into),
+                PhysicalComponentKind::Probe => func::Probe::deserialize_with_ctx(ctx, deserializer).map(Into::into),
+                PhysicalComponentKind::Mux => func::Mux::deserialize_with_ctx(ctx, deserializer).map(Into::into),
+                PhysicalComponentKind::Demux => func::Demux::deserialize_with_ctx(ctx, deserializer).map(Into::into),
+                PhysicalComponentKind::Decoder => func::Decoder::deserialize_with_ctx(ctx, deserializer).map(Into::into),
+                PhysicalComponentKind::Text => func::Text::deserialize_with_ctx(ctx, deserializer).map(Into::into),
+                PhysicalComponentKind::Subcircuit => func::Subcircuit::deserialize_with_ctx(ctx, deserializer).map(Into::into),
+                PhysicalComponentKind::Gate => func::Gate::deserialize_with_ctx(ctx, deserializer).map(Into::into),
+                PhysicalComponentKind::Not => func::Not::deserialize_with_ctx(ctx, deserializer).map(Into::into),
+                PhysicalComponentKind::TriState => func::TriState::deserialize_with_ctx(ctx, deserializer).map(Into::into),
+            }
+        }
+    }
+}
+pub(crate) use pcom_serde::PComDeserCtx;
 
 #[cfg(test)]
 mod tests {

--- a/packages/backend/src/middle_end/func/mod.rs
+++ b/packages/backend/src/middle_end/func/mod.rs
@@ -86,22 +86,27 @@ pub struct PhysicalInitContext<'a> {
 /// A component that can be added in a [middle-end circuit](`crate::middle_end::MiddleRepr`).
 #[enum_dispatch]
 pub trait PhysicalComponent {
-    /// A component which represents the engine logic of this component.
+    /// Initializes the component which represents the engine logic of this physical component,
+    /// based on the properties of the physical component.
     /// 
     /// This can be `None` if this component has no engine logic.
-    fn engine_component(&self) -> Option<ComponentFn>;
+    fn init_engine(&self) -> Option<ComponentFn>;
 
     /// The name of the component.
     fn component_name(&self) -> &'static str;
 
-    /// The area taken by this component, which includes:
-    ///   - The bounds of the component
+    /// Initializes the bounds of the physical component,
+    /// based on its properties.
+    /// 
+    /// The bounds are defined as:
+    ///   - The area encompassed of the component
+    ///     (defined by the top-leftmost point and the bottom-rightmost point)
     ///   - The position of the ports
     /// 
     /// These components are relative to the origin (0, 0),
     /// meaning that when placed, the locations are relative
     /// to the point the component is placed.
-    fn bounds(&self, ctx: PhysicalInitContext<'_>) -> RelativeComponentBounds;
+    fn init_bounds(&self, ctx: PhysicalInitContext<'_>) -> RelativeComponentBounds;
 }
 
 /// Struct containing the physical bounds of a component and location of ports.
@@ -156,7 +161,10 @@ impl RelativeComponentBounds {
             _ => Self::single_port(2 * MAX_COLS, height)
         }
     }
-    /// Orients the component bounds and ports according to the given orientation, assuming original orientation is East
+
+    /// Orients the component bounds and ports around the origin
+    /// in accordance to the specified orientation and handedness,
+    /// assuming the coordinates were originally oriented eastwards with down-right handedness.
     pub fn orient(self, orientation: Orientation, handedness: Handedness) -> Self {
         // Rotate bounds and ports, then get use the max and min of the corners to get new bounds:
         let Self { bounds: [b0, b1], ports } = self;
@@ -219,10 +227,10 @@ impl AbsoluteComponentBounds {
 
 #[enum_dispatch(PhysicalComponent)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum PhysicalComponentEnum {
     // Wiring
-    Input, Output, Constant, Splitter, Power, Ground, Tunnel, Probe,
+    Pin, Constant, Splitter, Power, Ground, Tunnel, Probe,
     // Muxes
     Mux, Demux, Decoder,
     // Misc

--- a/packages/backend/src/middle_end/func/mod.rs
+++ b/packages/backend/src/middle_end/func/mod.rs
@@ -73,8 +73,6 @@ pub enum Handedness {
     DownRight
 }
 
-
-
 /// Context available during [`PhysicalComponent`] initialization.
 pub struct PhysicalInitContext<'a> {
     /// The circuit this component is being placed in.
@@ -226,8 +224,13 @@ impl AbsoluteComponentBounds {
 }
 
 #[enum_dispatch(PhysicalComponent)]
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, strum::EnumDiscriminants, strum::IntoStaticStr)]
 #[expect(missing_docs)]
+#[strum_discriminants(
+    name(PhysicalComponentKind),
+    expect(missing_docs),
+    derive(strum::IntoStaticStr)
+)]
 pub enum PhysicalComponentEnum {
     // Wiring
     Pin, Constant, Splitter, Power, Ground, Tunnel, Probe,

--- a/packages/backend/src/middle_end/func/muxes.rs
+++ b/packages/backend/src/middle_end/func/muxes.rs
@@ -5,6 +5,7 @@ const PLEXER_WIDTH: u32 = 3;
 
 /// A multiplexer (mux) component.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[cfg_attr(feature="serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Mux {
     bitsize: u8,
     selsize: u8,
@@ -40,6 +41,7 @@ impl PhysicalComponent for Mux {
 
 /// A demultiplexer (demux) component.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[cfg_attr(feature="serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Demux {
     bitsize: u8,
     selsize: u8,
@@ -73,6 +75,7 @@ impl PhysicalComponent for Demux {
 
 /// A decoder component.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[cfg_attr(feature="serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Decoder {
     selsize: u8,
     orientation: Orientation,

--- a/packages/backend/src/middle_end/func/muxes.rs
+++ b/packages/backend/src/middle_end/func/muxes.rs
@@ -1,4 +1,4 @@
-use crate::engine::func::{self, ComponentFn};
+use crate::engine::func::{self, BitSize, ComponentFn, SelSize};
 use crate::middle_end::func::{AbsoluteComponentBounds, Handedness, Orientation, PhysicalComponent, PhysicalInitContext, RelativeComponentBounds};
 
 const PLEXER_WIDTH: u32 = 3;
@@ -7,14 +7,14 @@ const PLEXER_WIDTH: u32 = 3;
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 #[cfg_attr(feature="serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Mux {
-    bitsize: u8,
-    selsize: u8,
+    bitsize: BitSize,
+    selsize: SelSize,
     orientation: Orientation,
     handedness: Handedness
 }
 impl PhysicalComponent for Mux {
     fn init_engine(&self) -> Option<ComponentFn> {
-        Some(func::Mux::new(self.bitsize, self.selsize).into())
+        Some(func::Mux::new(self.bitsize.get(), self.selsize.get()).into())
     }
 
     fn component_name(&self) ->  &'static str {
@@ -43,14 +43,14 @@ impl PhysicalComponent for Mux {
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 #[cfg_attr(feature="serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Demux {
-    bitsize: u8,
-    selsize: u8,
+    bitsize: BitSize,
+    selsize: SelSize,
     orientation: Orientation,
     handedness: Handedness
 }
 impl PhysicalComponent for Demux {
     fn init_engine(&self) -> Option<ComponentFn> {
-        Some(func::Demux::new(self.bitsize, self.selsize).into())
+        Some(func::Demux::new(self.bitsize.get(), self.selsize.get()).into())
     }
 
     fn component_name(&self) ->  &'static str {
@@ -77,13 +77,13 @@ impl PhysicalComponent for Demux {
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 #[cfg_attr(feature="serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Decoder {
-    selsize: u8,
+    selsize: SelSize,
     orientation: Orientation,
     handedness: Handedness
 }
 impl PhysicalComponent for Decoder {
     fn init_engine(&self) -> Option<ComponentFn> {
-        Some(func::Decoder::new(self.selsize).into())
+        Some(func::Decoder::new(self.selsize.get()).into())
     }
 
     fn component_name(&self) ->  &'static str {

--- a/packages/backend/src/middle_end/func/muxes.rs
+++ b/packages/backend/src/middle_end/func/muxes.rs
@@ -1,24 +1,27 @@
 use crate::engine::func::{self, ComponentFn};
-use crate::middle_end::func::{AbsoluteComponentBounds, PhysicalComponent, PhysicalInitContext, RelativeComponentBounds};
+use crate::middle_end::func::{AbsoluteComponentBounds, Handedness, Orientation, PhysicalComponent, PhysicalInitContext, RelativeComponentBounds};
 
 const PLEXER_WIDTH: u32 = 3;
 
 /// A multiplexer (mux) component.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Mux {
-    sim: func::Mux
+    bitsize: u8,
+    selsize: u8,
+    orientation: Orientation,
+    handedness: Handedness
 }
 impl PhysicalComponent for Mux {
-    fn engine_component(&self) -> Option<ComponentFn> {
-        Some(self.sim.into())
+    fn init_engine(&self) -> Option<ComponentFn> {
+        Some(func::Mux::new(self.bitsize, self.selsize).into())
     }
 
     fn component_name(&self) ->  &'static str {
         "Mux"
     }
 
-    fn bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
-        let n_inputs: u32 = self.sim.n_inputs() as u32;
+    fn init_bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
+        let n_inputs: u32 = func::Mux::n_inputs_from(self.selsize) as u32;
         
         let width = PLEXER_WIDTH;
         let height = 2 * n_inputs;
@@ -31,25 +34,29 @@ impl PhysicalComponent for Mux {
 
         AbsoluteComponentBounds::new((width, height), ports)
             .into_relative(origin)
+            .orient(self.orientation, self.handedness)
     }
 }
 
 /// A demultiplexer (demux) component.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Demux {
-    sim: func::Demux
+    bitsize: u8,
+    selsize: u8,
+    orientation: Orientation,
+    handedness: Handedness
 }
 impl PhysicalComponent for Demux {
-    fn engine_component(&self) -> Option<ComponentFn> {
-        Some(self.sim.into())
+    fn init_engine(&self) -> Option<ComponentFn> {
+        Some(func::Demux::new(self.bitsize, self.selsize).into())
     }
 
     fn component_name(&self) ->  &'static str {
         "Demux"
     }
 
-    fn bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
-        let n_outputs = self.sim.n_outputs() as u32;
+    fn init_bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
+        let n_outputs = func::Demux::n_outputs_from(self.selsize) as u32;
         
         let width = PLEXER_WIDTH;
         let height = 2 * n_outputs;
@@ -60,25 +67,28 @@ impl PhysicalComponent for Demux {
 
         AbsoluteComponentBounds::new((width, height), ports)
             .into_relative(origin)
+            .orient(self.orientation, self.handedness)
     }
 }
 
 /// A decoder component.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Decoder {
-    sim: func::Decoder
+    selsize: u8,
+    orientation: Orientation,
+    handedness: Handedness
 }
 impl PhysicalComponent for Decoder {
-    fn engine_component(&self) -> Option<ComponentFn> {
-        Some(self.sim.into())
+    fn init_engine(&self) -> Option<ComponentFn> {
+        Some(func::Decoder::new(self.selsize).into())
     }
 
     fn component_name(&self) ->  &'static str {
         "Decoder"
     }
 
-    fn bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
-        let n_outputs = self.sim.n_outputs() as u32;
+    fn init_bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
+        let n_outputs = func::Decoder::n_outputs_from(self.selsize) as u32;
         
         let width = PLEXER_WIDTH;
         let height = 2 * n_outputs;
@@ -89,5 +99,6 @@ impl PhysicalComponent for Decoder {
 
         AbsoluteComponentBounds::new((width, height), ports)
             .into_relative(origin)
+            .orient(self.orientation, self.handedness)
     }
 }

--- a/packages/backend/src/middle_end/func/wiring.rs
+++ b/packages/backend/src/middle_end/func/wiring.rs
@@ -1,61 +1,54 @@
+use crate::bitarray::BitArray;
 use crate::engine::func;
 use crate::bitarr;
-use crate::middle_end::func::{PhysicalComponent, PhysicalInitContext, RelativeComponentBounds};
+use crate::middle_end::func::{Handedness, Orientation, PhysicalComponent, PhysicalInitContext, RelativeComponentBounds};
 
 /// An input.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
-pub struct Input {
-    sim: func::Input
+pub struct Pin {
+    bitsize: u8,
+    is_input: bool,
+    orientation: Orientation
 }
-impl PhysicalComponent for Input {
-    fn engine_component(&self) -> Option<func::ComponentFn> {
-        Some(self.sim.into())
+impl PhysicalComponent for Pin {
+    fn init_engine(&self) -> Option<func::ComponentFn> {
+        Some(match self.is_input {
+            true  => func::Input::new(self.bitsize).into(),
+            false => func::Output::new(self.bitsize).into()
+        })
     }
 
     fn component_name(&self) -> &'static str {
-        "Input"
+        match self.is_input {
+            true  => "Input",
+            false => "Output"
+        }
     }
 
-    fn bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
-        RelativeComponentBounds::single_port_from_bitsize(self.sim.get_bitsize())
-    }
-}
-
-/// An output.
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
-pub struct Output {
-    sim: func::Output
-}
-impl PhysicalComponent for Output {
-    fn engine_component(&self) -> Option<func::ComponentFn> {
-        Some(self.sim.into())
-    }
-
-    fn component_name(&self) -> &'static str {
-        "Output"
-    }
-
-    fn bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
-        RelativeComponentBounds::single_port_from_bitsize(self.sim.get_bitsize())
+    fn init_bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
+        RelativeComponentBounds::single_port_from_bitsize(self.bitsize)
+            .orient(self.orientation, Default::default())
     }
 }
 
 /// A constant.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Constant {
-    sim: func::Constant
+    value: BitArray,
+    orientation: Orientation
 }
 impl PhysicalComponent for Constant {
-    fn engine_component(&self) -> Option<func::ComponentFn> {
-        Some(self.sim.into())
+    fn init_engine(&self) -> Option<func::ComponentFn> {
+        Some(func::Constant::new(self.value).into())
     }
 
     fn component_name(&self) -> &'static str {
         "Constant"
     }
 
-    fn bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
-        RelativeComponentBounds::single_port_from_bitsize(self.sim.get_value().len())
+    fn init_bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
+        RelativeComponentBounds::single_port_from_bitsize(self.value.len())
+            .orient(self.orientation, Default::default())
     }
 }
 
@@ -63,7 +56,7 @@ impl PhysicalComponent for Constant {
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Power;
 impl PhysicalComponent for Power {
-    fn engine_component(&self) -> Option<func::ComponentFn> {
+    fn init_engine(&self) -> Option<func::ComponentFn> {
         Some(func::Constant::new(bitarr![1]).into())
     }
 
@@ -71,7 +64,7 @@ impl PhysicalComponent for Power {
         "Power"
     }
 
-    fn bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
+    fn init_bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
         RelativeComponentBounds::single_port_with_origin(2, 3, (1, 3))
     }
 }
@@ -80,7 +73,7 @@ impl PhysicalComponent for Power {
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Ground;
 impl PhysicalComponent for Ground {
-    fn engine_component(&self) -> Option<func::ComponentFn> {
+    fn init_engine(&self) -> Option<func::ComponentFn> {
         Some(func::Constant::new(bitarr![0]).into())
     }
 
@@ -88,7 +81,7 @@ impl PhysicalComponent for Ground {
         "Ground"
     }
 
-    fn bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
+    fn init_bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
         RelativeComponentBounds::single_port_with_origin(2, 3, (1, 0))
     }
 }
@@ -96,31 +89,36 @@ impl PhysicalComponent for Ground {
 /// A splitter component.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Splitter {
-    sim: func::Splitter
+    bitsize: u8,
+    orientation: Orientation,
+    handedness: Handedness
 }
 impl PhysicalComponent for Splitter {
-    fn engine_component(&self) -> Option<func::ComponentFn> {
-        Some(self.sim.into())
+    fn init_engine(&self) -> Option<func::ComponentFn> {
+        Some(func::Splitter::new(self.bitsize).into())
     }
 
     fn component_name(&self) -> &'static str {
         "Splitter"
     }
 
-    fn bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
-        let bitsize = i32::from(self.sim.get_bitsize());
+    fn init_bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
+        let bitsize = i32::from(self.bitsize);
         let mut ports = vec![(0, 0)];
         ports.extend((1..=bitsize).map(|i| (2 * i, 2)));
 
         RelativeComponentBounds::new((bitsize * 2, 2), ports)
+            .orient(self.orientation, self.handedness)
     }
 }
 
 /// A tunnel.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
-pub struct Tunnel;
+pub struct Tunnel {
+    orientation: Orientation
+}
 impl PhysicalComponent for Tunnel {
-    fn engine_component(&self) -> Option<func::ComponentFn> {
+    fn init_engine(&self) -> Option<func::ComponentFn> {
         None
     }
 
@@ -128,16 +126,19 @@ impl PhysicalComponent for Tunnel {
         "Tunnel"
     }
 
-    fn bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
+    fn init_bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
         RelativeComponentBounds::single_port_with_origin(3, 2, (3, 1))
+            .orient(self.orientation, Default::default())
     }
 }
 
 /// A probe.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
-pub struct Probe;
+pub struct Probe {
+    orientation: Orientation
+}
 impl PhysicalComponent for Probe {
-    fn engine_component(&self) -> Option<func::ComponentFn> {
+    fn init_engine(&self) -> Option<func::ComponentFn> {
         None
     }
 
@@ -145,8 +146,9 @@ impl PhysicalComponent for Probe {
         "Probe"
     }
 
-    fn bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
+    fn init_bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
         RelativeComponentBounds::single_port(2, 2)
+            .orient(self.orientation, Default::default())
     }
 }
 

--- a/packages/backend/src/middle_end/func/wiring.rs
+++ b/packages/backend/src/middle_end/func/wiring.rs
@@ -1,5 +1,5 @@
 use crate::bitarray::BitArray;
-use crate::engine::func;
+use crate::engine::func::{self, BitSize};
 use crate::bitarr;
 use crate::middle_end::func::{Handedness, Orientation, PhysicalComponent, PhysicalInitContext, RelativeComponentBounds};
 
@@ -7,15 +7,15 @@ use crate::middle_end::func::{Handedness, Orientation, PhysicalComponent, Physic
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 #[cfg_attr(feature="serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Pin {
-    bitsize: u8,
+    bitsize: BitSize,
     is_input: bool,
     orientation: Orientation
 }
 impl PhysicalComponent for Pin {
     fn init_engine(&self) -> Option<func::ComponentFn> {
         Some(match self.is_input {
-            true  => func::Input::new(self.bitsize).into(),
-            false => func::Output::new(self.bitsize).into()
+            true  => func::Input::new(self.bitsize.get()).into(),
+            false => func::Output::new(self.bitsize.get()).into()
         })
     }
 
@@ -27,7 +27,7 @@ impl PhysicalComponent for Pin {
     }
 
     fn init_bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
-        RelativeComponentBounds::single_port_from_bitsize(self.bitsize)
+        RelativeComponentBounds::single_port_from_bitsize(self.bitsize.get())
             .orient(self.orientation, Default::default())
     }
 }
@@ -94,13 +94,13 @@ impl PhysicalComponent for Ground {
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 #[cfg_attr(feature="serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Splitter {
-    bitsize: u8,
+    bitsize: BitSize,
     orientation: Orientation,
     handedness: Handedness
 }
 impl PhysicalComponent for Splitter {
     fn init_engine(&self) -> Option<func::ComponentFn> {
-        Some(func::Splitter::new(self.bitsize).into())
+        Some(func::Splitter::new(self.bitsize.get()).into())
     }
 
     fn component_name(&self) -> &'static str {
@@ -108,7 +108,7 @@ impl PhysicalComponent for Splitter {
     }
 
     fn init_bounds(&self, _: PhysicalInitContext<'_>) -> RelativeComponentBounds {
-        let bitsize = i32::from(self.bitsize);
+        let bitsize = i32::from(self.bitsize.get());
         let mut ports = vec![(0, 0)];
         ports.extend((1..=bitsize).map(|i| (2 * i, 2)));
 

--- a/packages/backend/src/middle_end/func/wiring.rs
+++ b/packages/backend/src/middle_end/func/wiring.rs
@@ -5,6 +5,7 @@ use crate::middle_end::func::{Handedness, Orientation, PhysicalComponent, Physic
 
 /// An input.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[cfg_attr(feature="serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Pin {
     bitsize: u8,
     is_input: bool,
@@ -33,6 +34,7 @@ impl PhysicalComponent for Pin {
 
 /// A constant.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[cfg_attr(feature="serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Constant {
     value: BitArray,
     orientation: Orientation
@@ -54,6 +56,7 @@ impl PhysicalComponent for Constant {
 
 /// Power (essentially a constant 1).
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[cfg_attr(feature="serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Power;
 impl PhysicalComponent for Power {
     fn init_engine(&self) -> Option<func::ComponentFn> {
@@ -71,6 +74,7 @@ impl PhysicalComponent for Power {
 
 /// Ground (essentially a constant 0).
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[cfg_attr(feature="serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Ground;
 impl PhysicalComponent for Ground {
     fn init_engine(&self) -> Option<func::ComponentFn> {
@@ -88,6 +92,7 @@ impl PhysicalComponent for Ground {
 
 /// A splitter component.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[cfg_attr(feature="serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Splitter {
     bitsize: u8,
     orientation: Orientation,
@@ -114,6 +119,7 @@ impl PhysicalComponent for Splitter {
 
 /// A tunnel.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[cfg_attr(feature="serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Tunnel {
     orientation: Orientation
 }
@@ -134,6 +140,7 @@ impl PhysicalComponent for Tunnel {
 
 /// A probe.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[cfg_attr(feature="serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Probe {
     orientation: Orientation
 }

--- a/packages/backend/src/middle_end/mod.rs
+++ b/packages/backend/src/middle_end/mod.rs
@@ -39,6 +39,7 @@ pub struct MiddleRepr {
 ///   including their locations and properties.
 #[derive(Debug, Default)]
 struct CircuitArea {
+    name: String,
     components: SecondaryMap<FunctionKey, ComponentProps>,
     ui_components: SlotMap<UIKey, ComponentProps>,
     wires: WireSet,
@@ -92,11 +93,18 @@ impl MiddleRepr {
         Self::default()
     }
     /// Creates a new subcircuit.
-    pub fn add_circuit(&mut self) -> CircuitKey {
+    pub fn add_circuit(&mut self, name: &str) -> CircuitKey {
         let ck = self.engine.add_circuit();
-        self.physical.insert(ck, CircuitArea::default());
+
+        let area = CircuitArea {
+            name: name.to_string(),
+            ..Default::default()
+        };
+        self.physical.insert(ck, area);
+
         ck
     }
+
     /// Creates a mutable view for a given subcircuit.
     pub fn circuit(&mut self, key: CircuitKey) -> MiddleCircuit<'_> {
         MiddleCircuit { repr: self, key }

--- a/packages/backend/src/middle_end/mod.rs
+++ b/packages/backend/src/middle_end/mod.rs
@@ -15,6 +15,7 @@ use crate::middle_end::wire::{Wire, WireSet};
 
 mod key;
 mod string_interner;
+#[cfg(feature="serde")]
 pub mod serialize;
 pub mod wire;
 pub mod func;

--- a/packages/backend/src/middle_end/mod.rs
+++ b/packages/backend/src/middle_end/mod.rs
@@ -6,6 +6,7 @@
 //! 
 
 use slotmap::{SecondaryMap, SlotMap};
+use thiserror::Error;
 
 use crate::engine::{CircuitForest, CircuitKey, FunctionKey, FunctionPort};
 use crate::middle_end::func::{ComponentBounds, PhysicalComponent, PhysicalComponentEnum, PhysicalInitContext};
@@ -58,15 +59,22 @@ struct ComponentProps {
     extra: PhysicalComponentEnum
 }
 
+#[derive(Debug, Error)]
 /// Errors which can occur when editing a middle-end circuit.
 pub enum ReprEditErr {
-    /// Adding a component fails.
-    CannotAddComponent,
-    /// Removing a component fails.
-    CannotRemoveComponent,
+    /// Component is out of bounds (so it cannot be added).
+    #[error("component is out of bounds")]
+    ComponentOutOfBounds,
+    
+    /// Component being specified doesn't exist (so it cannot be removed).
+    #[error("component does not exist")]
+    ComponentDoesNotExist,
+
     /// Adding a wire fails.
+    #[error("cannot add wire")]
     CannotAddWire,
     /// Removing a wire fails.
+    #[error("cannot remove wire")]
     CannotRemoveWire,
 }
 
@@ -102,13 +110,13 @@ impl MiddleCircuit<'_> {
     /// Adds a component to the circuit.
     /// 
     /// This takes the component, label, and location for the component.
-    /// This returns [`ReprEditErr::CannotAddComponent`] if it fails, which can occur if the component would be out of bounds. Otherwise, return the component key associated with added component.
+    /// This returns [`ReprEditErr::ComponentOutOfBounds`] if it fails, which can occur if the component would be out of bounds. Otherwise, return the component key associated with added component.
     pub fn add_component<C: Into<PhysicalComponentEnum>>(&mut self, physical: C, label: &str, pos: Coord) -> Result<ComponentKey, ReprEditErr> {
         let ctx = PhysicalInitContext { circuit: self, label };
         let physical = physical.into();
         let ComponentBounds { bounds, ports } = physical.init_bounds(ctx)
             .into_absolute(pos)
-            .ok_or(ReprEditErr::CannotAddComponent)?;
+            .ok_or(ReprEditErr::ComponentOutOfBounds)?;
         let props = ComponentProps {
             label: label.to_string(),
             origin: pos,
@@ -150,12 +158,12 @@ impl MiddleCircuit<'_> {
 
     /// Removes a component from the circuit.
     /// 
-    /// This returns [`ReprEditErr::CannotRemoveComponent`] if the component does not exist.
+    /// This returns [`ReprEditErr::ComponentDoesNotExist`] if the component does not exist.
     pub fn remove_component(&mut self, key: ComponentKey) -> Result<(), ReprEditErr> {
         let props = match key {
             ComponentKey::Function(gate) => circ!(self.physical).components.remove(gate),
             ComponentKey::UI(key) => circ!(self.physical).ui_components.remove(key),
-        }.ok_or(ReprEditErr::CannotRemoveComponent)?;
+        }.ok_or(ReprEditErr::ComponentDoesNotExist)?;
 
         // Remove from engine (if applicable):
         if let ComponentKey::Function(gate) = key {

--- a/packages/backend/src/middle_end/mod.rs
+++ b/packages/backend/src/middle_end/mod.rs
@@ -9,7 +9,7 @@ use slotmap::{SecondaryMap, SlotMap};
 use thiserror::Error;
 
 use crate::engine::{CircuitForest, CircuitKey, FunctionKey, FunctionPort};
-use crate::middle_end::func::{ComponentBounds, PhysicalComponent, PhysicalComponentEnum, PhysicalInitContext};
+use crate::middle_end::func::{ComponentBounds, Orientation, PhysicalComponent, PhysicalComponentEnum, PhysicalInitContext};
 use crate::middle_end::string_interner::StringInterner;
 use crate::middle_end::wire::{Wire, WireSet};
 
@@ -49,14 +49,15 @@ struct CircuitArea {
 #[derive(Debug)]
 struct ComponentProps {
     label: String,
+    label_location: Orientation,
 
     // Position
     origin: Coord,
     bounds: [Coord; 2],
     ports: Vec<Coord>,
 
-    // Extra props
-    extra: PhysicalComponentEnum
+    // Component-specific props
+    inner: PhysicalComponentEnum
 }
 
 #[derive(Debug, Error)]
@@ -90,6 +91,12 @@ impl MiddleRepr {
     pub fn new() -> Self {
         Self::default()
     }
+    /// Creates a new subcircuit.
+    pub fn add_circuit(&mut self) -> CircuitKey {
+        let ck = self.engine.add_circuit();
+        self.physical.insert(ck, CircuitArea::default());
+        ck
+    }
     /// Creates a mutable view for a given subcircuit.
     pub fn circuit(&mut self, key: CircuitKey) -> MiddleCircuit<'_> {
         MiddleCircuit { repr: self, key }
@@ -119,10 +126,11 @@ impl MiddleCircuit<'_> {
             .ok_or(ReprEditErr::ComponentOutOfBounds)?;
         let props = ComponentProps {
             label: label.to_string(),
+            label_location: Orientation::North,
             origin: pos,
             bounds,
             ports,
-            extra: physical,
+            inner: physical,
         };
 
         if let Some(component) = physical.init_engine() {
@@ -144,7 +152,7 @@ impl MiddleCircuit<'_> {
             // ~~~ UI component ~~~
 
             // Add tunnel to wire set:
-            if !props.label.is_empty() && matches!(props.extra, PhysicalComponentEnum::Tunnel(_)) {
+            if !props.label.is_empty() && matches!(props.inner, PhysicalComponentEnum::Tunnel(_)) {
                 let &[coord] = props.ports.as_slice() else { unreachable!("Tunnel should have 1 port") };
                 let sym = circ!(self.physical).tunnel_interner.add_ref(&props.label);
                 circ!(self.physical).wires.add_tunnel(coord, sym, || circ!(self.engine).add_value_node());
@@ -172,7 +180,7 @@ impl MiddleCircuit<'_> {
         }
         
         // Handle tunnels specially:
-        if matches!(props.extra, PhysicalComponentEnum::Tunnel(_)) {
+        if matches!(props.inner, PhysicalComponentEnum::Tunnel(_)) {
             let sym = circ!(self.physical).tunnel_interner.del_ref(&props.label)
                 .expect("Tunnel should have an assigned symbol");
             circ!(self.physical).wires.remove_tunnel(props.origin, sym)

--- a/packages/backend/src/middle_end/mod.rs
+++ b/packages/backend/src/middle_end/mod.rs
@@ -8,7 +8,7 @@
 use slotmap::{SecondaryMap, SlotMap};
 
 use crate::engine::{CircuitForest, CircuitKey, FunctionKey, FunctionPort};
-use crate::middle_end::func::{ComponentBounds, Handedness, Orientation, PhysicalComponent, PhysicalComponentEnum, PhysicalInitContext};
+use crate::middle_end::func::{ComponentBounds, PhysicalComponent, PhysicalComponentEnum, PhysicalInitContext};
 use crate::middle_end::string_interner::StringInterner;
 use crate::middle_end::wire::{Wire, WireSet};
 
@@ -53,8 +53,6 @@ struct ComponentProps {
     origin: Coord,
     bounds: [Coord; 2],
     ports: Vec<Coord>,
-    orientation: Orientation,
-    handedness: Handedness,
 
     // Extra props
     extra: PhysicalComponentEnum
@@ -108,19 +106,18 @@ impl MiddleCircuit<'_> {
     pub fn add_component<C: Into<PhysicalComponentEnum>>(&mut self, physical: C, label: &str, pos: Coord) -> Result<ComponentKey, ReprEditErr> {
         let ctx = PhysicalInitContext { circuit: self, label };
         let physical = physical.into();
-        let ComponentBounds { bounds, ports } = physical.bounds(ctx).into_absolute(pos)
+        let ComponentBounds { bounds, ports } = physical.init_bounds(ctx)
+            .into_absolute(pos)
             .ok_or(ReprEditErr::CannotAddComponent)?;
         let props = ComponentProps {
             label: label.to_string(),
             origin: pos,
             bounds,
             ports,
-            orientation: Default::default(),
-            handedness: Default::default(),
             extra: physical,
         };
 
-        if let Some(component) = physical.engine_component() {
+        if let Some(component) = physical.init_engine() {
             // ~~~ Engine component ~~~
             let gate = circ!(self.engine).add_function_node(component);
             
@@ -214,69 +211,6 @@ impl MiddleCircuit<'_> {
             .ok_or(ReprEditErr::CannotRemoveWire)?;
 
         self.handle_remove(result);
-
-        Ok(())
-    }
-    /// Sets the orientation of a component, and updates the circuit to accommodate the new orientation.
-    pub fn set_component_orientation(&mut self, key: ComponentKey, orientation: Orientation) -> Result<(), ReprEditErr> {
-        //Extract component properties
-        let props = match key {
-            ComponentKey::Function(gate) => circ!(self.physical).components.get_mut(gate)
-                .ok_or(ReprEditErr::CannotRemoveComponent)?,
-            ComponentKey::UI(ui_key) => circ!(self.physical).ui_components.get_mut(ui_key)
-                .ok_or(ReprEditErr::CannotRemoveComponent)?,
-        };
-        //extract properties that we will need to update:
-        let (label, origin, old_ports, physical, handedness) = (
-            props.label.clone(),
-            props.origin,
-            props.ports.clone(),
-            props.extra,
-            props.handedness,
-        );
-
-        // Get new bounds and ports: the extra property of props stores the physical component unaffected by orientation, so we can reuse it to get the new bounds and ports for the component with the new orientation.
-        let ComponentBounds { bounds, ports } = physical
-            .bounds(PhysicalInitContext { circuit: self, label: &label })
-            .orient(orientation, handedness)
-            .into_absolute(origin)
-            .ok_or(ReprEditErr::CannotAddComponent)?;
-
-        if !matches!(physical, PhysicalComponentEnum::Tunnel(_)) {
-            // Tunnel port is unaffected by orientation changes bc there is only one port, however for both ui and engine componets there are multiple ports whose positions are affected
-            for index in 0..old_ports.len() {
-                    let result = circ!(self.physical).wires.remove_port(key, index)
-                        .expect("Component removal should succeed");
-                    self.handle_remove(result);
-                }
-        } 
-            
-        
-        // Add new ports to wire set:
-        if let ComponentKey::Function(gate) = key {
-            for (index, &coord) in ports.iter().enumerate() {
-                let value = circ!(self.physical).wires.add_port(coord, key, index, || circ!(self.engine).add_value_node())
-                    .expect("Expected port addition to be successful");
-                circ!(self.engine).connect_one(value, FunctionPort { gate, index });
-            }
-        } 
-            // Update component properties:
-        match key {
-            ComponentKey::Function(gate) => {
-                let props = circ!(self.physical).components.get_mut(gate)
-                    .ok_or(ReprEditErr::CannotRemoveComponent)?;
-                props.bounds = bounds;
-                props.ports = ports;
-                props.orientation = orientation;
-            }
-            ComponentKey::UI(ui_key) => {
-                let props = circ!(self.physical).ui_components.get_mut(ui_key)
-                    .ok_or(ReprEditErr::CannotRemoveComponent)?;
-                props.bounds = bounds;
-                props.ports = ports;
-                props.orientation = orientation;
-            }
-        }
 
         Ok(())
     }

--- a/packages/backend/src/middle_end/mod.rs
+++ b/packages/backend/src/middle_end/mod.rs
@@ -126,7 +126,7 @@ impl MiddleCircuit<'_> {
     /// 
     /// This takes the component, label, and location for the component.
     /// This returns [`ReprEditErr::ComponentOutOfBounds`] if it fails, which can occur if the component would be out of bounds. Otherwise, return the component key associated with added component.
-    pub fn add_component<C: Into<PhysicalComponentEnum>>(&mut self, physical: C, label: &str, pos: Coord) -> Result<ComponentKey, ReprEditErr> {
+    pub fn add_component<C: Into<PhysicalComponentEnum>>(&mut self, physical: C, label: &str, label_location: Orientation, pos: Coord) -> Result<ComponentKey, ReprEditErr> {
         let ctx = PhysicalInitContext { circuit: self, label };
         let physical = physical.into();
         let ComponentBounds { bounds, ports } = physical.init_bounds(ctx)
@@ -134,7 +134,7 @@ impl MiddleCircuit<'_> {
             .ok_or(ReprEditErr::ComponentOutOfBounds)?;
         let props = ComponentProps {
             label: label.to_string(),
-            label_location: Orientation::North,
+            label_location,
             origin: pos,
             bounds,
             ports,

--- a/packages/backend/src/middle_end/mod.rs
+++ b/packages/backend/src/middle_end/mod.rs
@@ -31,6 +31,7 @@ type CoordDelta = (AxisDelta, AxisDelta);
 
 /// A group of middle circuits.
 #[derive(Debug, Default)]
+#[cfg_attr(feature="serde", derive(serde::Deserialize), serde(try_from = "serialize::CircuitFile"))]
 pub struct MiddleRepr {
     engine: CircuitForest,
     physical: SecondaryMap<CircuitKey, CircuitArea>

--- a/packages/backend/src/middle_end/serialize.rs
+++ b/packages/backend/src/middle_end/serialize.rs
@@ -5,10 +5,13 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::fs;
 
-use serde::{Deserialize, Serialize};
+use serde::de::IntoDeserializer;
+use serde::{Deserialize, Serialize, Serializer};
+use strum::IntoDiscriminant;
 use thiserror::Error;
 
-use crate::middle_end::Wire;
+use crate::middle_end::{ReprEditErr, Wire};
+use crate::middle_end::func::{Orientation, PComDeserCtx, PhysicalComponentEnum, PhysicalComponentKind};
 
 /// An error which can occur when serializing or deserializing a `.sim` file.
 #[derive(Debug, Error)]
@@ -35,6 +38,14 @@ pub enum SerdeError {
     /// Error which occurs during file serialization.
     #[error("failed to serialize .sim JSON: {0}")]
     Serialize(serde_json::Error),
+    /// Error which occurs when constructing the middle representation.
+    #[error("failed to create repr: {0}")]
+    ReprCreation(ReprEditErr),
+}
+impl From<ReprEditErr> for SerdeError {
+    fn from(value: ReprEditErr) -> Self {
+        Self::ReprCreation(value)
+    }
 }
 
 /// A serialized version of the middle-end representation,
@@ -105,11 +116,145 @@ pub struct CircuitInfo {
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct ComponentInfo {
     /// Component type.
-    pub name: String,
+    pub name: PhysicalComponentKind,
     /// Position x.
     pub x: u32,
     /// Position y.
     pub y: u32,
     /// Properties of the component.
-    pub properties: HashMap<String, String>,
+    pub properties: ComponentPropertiesInfo,
+}
+
+/// Serialized version of the properties of a component.
+/// 
+/// This is stored in the "properties" field of a [`ComponentInfo`].
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub struct ComponentPropertiesInfo {
+    /// Label.
+    pub label: String,
+    /// Location of label.
+    pub label_location: Orientation,
+    /// Internal properties of component.
+    #[serde(flatten)]
+    pub inner: serde_json::Value,
+}
+
+impl Serialize for super::MiddleRepr {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where S: Serializer
+    {
+        self.to_circuit_file()
+            .map_err(serde::ser::Error::custom)?
+            .serialize(serializer)
+    }
+}
+impl super::MiddleRepr {
+    fn to_circuit_file(&self) -> Result<CircuitFile, SerdeError> {
+        let version = format!("foret-{}", {
+            option_env!("CARGO_PKG_VERSION")
+                .unwrap_or("unknown")
+        });
+        
+        let circuits = self.physical.values()
+            .map(|area| Ok(CircuitInfo {
+                name: area.name.to_string(),
+                components: {
+                    area.components.values()
+                        .chain(area.ui_components.values())
+                        .map(|props| {
+                            let (x, y) = props.origin;
+                            Ok(ComponentInfo {
+                                name: props.inner.discriminant(),
+                                x, y,
+                                properties: ComponentPropertiesInfo {
+                                    label: props.label.to_string(),
+                                    label_location: props.label_location,
+                                    inner: props.inner.serialize_with_ctx(self, serde_json::value::Serializer)?,
+                                },
+                            })
+                        })
+                        .collect::<Result<_, _>>()
+                        .map_err(SerdeError::Serialize)?
+                },
+                wires: area.wires.wires().collect()
+            }))
+            .collect::<Result<_, SerdeError>>()?;
+
+        Ok(CircuitFile {
+            version,
+            // TODO: these fields aren't currently tracked anywhere
+            global_bitsize: 1,
+            clock_speed: 64,
+            //
+            circuits,
+            // TODO: compute these
+            revision_signatures: vec![],
+        })
+    }
+}
+
+impl TryFrom<CircuitFile> for super::MiddleRepr {
+    type Error = SerdeError;
+
+    fn try_from(value: CircuitFile) -> Result<Self, Self::Error> {
+        // TODO: Validate version, global_bitsize, clock_speed, each component
+
+        let mut repr = super::MiddleRepr::new();
+        let circuit_map: HashMap<_, _> = value.circuits.iter()
+            .map(|c| (c.name.to_string(), repr.add_circuit(&c.name)))
+            .collect();
+        
+        for CircuitInfo { name, components, wires } in value.circuits {
+            let mut circuit = repr.circuit(circuit_map[&name]);
+
+            for c in components {
+                let ComponentInfo { name: kind, x, y, properties } = c;
+                let ComponentPropertiesInfo { label, label_location, inner } = properties;
+                
+                let inner = PhysicalComponentEnum::deserialize_with_ctx(
+                    PComDeserCtx { kind, circuit_map: &circuit_map },
+                    inner.into_deserializer()
+                ).map_err(SerdeError::Deserialize)?;
+                
+                circuit.add_component(inner, &label, label_location, (x, y))?;
+            }
+
+            wires.into_iter()
+                .try_for_each(|w| circuit.add_wire(w))?;
+        }
+        Ok(repr)
+    }
+}
+
+/// Applies serialization with state (context).
+pub trait SerializeWithCtx<Ctx> {
+    /// Serializes with the provided serializer, using the given context.
+    fn serialize_with_ctx<S>(&self, ctx: &Ctx, serializer: S) -> Result<S::Ok, S::Error>
+        where S: Serializer;
+}
+impl<Ctx, T: Serialize> SerializeWithCtx<Ctx> for T {
+    fn serialize_with_ctx<S>(&self, _: &Ctx, serializer: S) -> Result<S::Ok, S::Error>
+        where S: Serializer
+    {
+        self.serialize(serializer)
+    }
+}
+
+/// Applies deserialization with state (context).
+/// 
+/// Note that [`serde::DeserializeSeed`] also does deserialization with state.
+/// The difference is that this trait automatically implements deserialization for all contexts
+///     if the type implements [`Deserialize`],
+///     which is useful for making uniform calls.
+pub trait DeserializeWithCtx<'de, Ctx>: Sized {
+    /// Deserializes with the provided desiralizer, using the given context.
+    fn deserialize_with_ctx<D>(ctx: Ctx, deserializer: D) -> Result<Self, D::Error>
+        where D: serde::Deserializer<'de>;
+}
+impl<'de, Ctx, T: Deserialize<'de>> DeserializeWithCtx<'de, Ctx> for T {
+    fn deserialize_with_ctx<D>(_: Ctx, deserializer: D) -> Result<Self, D::Error>
+        where D: serde::Deserializer<'de>
+    {
+        Self::deserialize(deserializer)
+    }
 }

--- a/packages/backend/src/middle_end/serialize.rs
+++ b/packages/backend/src/middle_end/serialize.rs
@@ -3,16 +3,18 @@
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::{fmt, fs};
+use std::fs;
 
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
 use crate::middle_end::Wire;
 
 /// An error which can occur when serializing or deserializing a `.sim` file.
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum SerdeError {
     /// Error which occurs when reading a file.
+    #[error("failed to read .sim file '{}': {source}", path.display())]
     ReadFile {
         /// The path which was read.
         path: PathBuf,
@@ -20,37 +22,20 @@ pub enum SerdeError {
         source: std::io::Error,
     },
     /// Error which occurs when writing a file.
+    #[error("failed to write .sim file '{}': {source}", path.display())]
     WriteFile {
         /// The path which was written to.
         path: PathBuf,
         /// The error.
         source: std::io::Error,
     },
-    /// Error which occurs during file deserialization.
+    /// Error which occurs during file deserialization
+    #[error("failed to deserialize .sim JSON: {0}")]
     Deserialize(serde_json::Error),
     /// Error which occurs during file serialization.
+    #[error("failed to serialize .sim JSON: {0}")]
     Serialize(serde_json::Error),
 }
-
-impl fmt::Display for SerdeError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::ReadFile { path, source } => {
-                write!(f, "failed to read .sim file '{}': {source}", path.display())
-            }
-            Self::WriteFile { path, source } => {
-                write!(
-                    f,
-                    "failed to write .sim file '{}': {source}",
-                    path.display()
-                )
-            }
-            Self::Deserialize(source) => write!(f, "failed to deserialize .sim JSON: {source}"),
-            Self::Serialize(source) => write!(f, "failed to serialize .sim JSON: {source}"),
-        }
-    }
-}
-impl std::error::Error for SerdeError {}
 
 /// A serialized version of the middle-end representation,
 /// which is used when saving and loading from .sim files.

--- a/packages/backend/src/middle_end/wire/mod.rs
+++ b/packages/backend/src/middle_end/wire/mod.rs
@@ -19,7 +19,8 @@ fn minmax<T: Ord>(p: T, q: T) -> [T; 2] {
 }
 
 /// A wire.
-#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
+#[cfg_attr(feature="serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Wire {
     /// The lowermost X coordinate of the wire.
     x: Axis,
@@ -28,7 +29,7 @@ pub struct Wire {
     /// The length of the wire.
     length: NonZero<Axis>,
     /// Whether the wire is horizontal or vertical.
-    #[serde(rename = "isHorizontal")]
+    #[cfg_attr(feature="serde", serde(rename = "isHorizontal"))]
     horizontal: bool
 }
 impl Wire {

--- a/packages/backend/src/middle_end/wire/wire_set.rs
+++ b/packages/backend/src/middle_end/wire/wire_set.rs
@@ -440,6 +440,11 @@ impl WireSet {
     pub fn wires_at_coord(&self, c: Coord) -> impl Iterator<Item = Wire> {
         self.ranges.wires_at_coord(c)
     }
+
+    /// Gets all of the wires defined in the set.
+    pub fn wires(&self) -> impl Iterator<Item=Wire> {
+        self.ranges.wires()
+    }
 }
 
 #[cfg(test)]

--- a/packages/backend/tests/serialize.rs
+++ b/packages/backend/tests/serialize.rs
@@ -1,3 +1,5 @@
+#![cfg(feature="serde")]
+
 use std::path::Path;
 
 use circuitsim_engine::middle_end::serialize::{CircuitFile, SerdeError};


### PR DESCRIPTION
Supersedes #12 and #13, by combining them into a (more?) cohesive PR

---

Implements middle-end serialization/deserialization:
- Adds strum and thiserror for simpler implementation of various items (from #12)
- Restructures middle end component types to contain all their properties and renames the methods of the PhysicalComponent trait to account for that (from #12)
- Implements `serde::Serialize` and `serde::Deserialize` for MiddleRepr (from #13)

Closes #6, #17